### PR TITLE
Composer: update the license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "clicky"
   ],
   "homepage": "https://yoast.com/wordpress/plugins/clicky/",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Joost de Valk",


### PR DESCRIPTION
Updates the license identifier in the composer.json file to `GPL-2.0-or-later`.

As of Composer 1.6.0, the SPDX license identifiers v3.0 for GPL/LGPL/AGPL are supported and using the old license identifiers has been deprecated.

Refs:
* https://github.com/composer/composer/releases/tag/1.6.0
* https://spdx.org/news/news/2018/01/license-list-30-released