### PR TITLE
QA: remove text-domain from readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,6 @@ Tags: analytics, statistics, clicky, getclicky, affiliate, outbound links, analy
 Requires at least: 4.9
 Tested up to: 5.1
 Stable tag: 1.7
-Text Domain: clicky
 
 Integrates the Clicky web analytics service into your blog and adds features for comment tracking & more.
 


### PR DESCRIPTION
The `Text domain` tag should be used in the plugin header in the main PHP file, not in the readme.

Refs:
* https://developer.wordpress.org/plugins/plugin-basics/header-requirements/
* https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/

Fixes #8