### PR TITLE
CS/QA: remove redundant index.php files

### DIFF
--- a/tests/framework/index.php
+++ b/tests/framework/index.php
@@ -1,2 +1,0 @@
-<?php
-//Nothing to see here

--- a/tests/index.php
+++ b/tests/index.php
@@ -1,2 +1,0 @@
-<?php
-//Nothing to see here


### PR DESCRIPTION
As the tests are not shipped with the plugin, the test directories do not need an `index.php` file to prevent incorrectly configured servers from serving a file list.