### PR TITLE
CS: all methods and properties should have visibility declared

### DIFF
--- a/tests/test-class-clicky-options-admin.php
+++ b/tests/test-class-clicky-options-admin.php
@@ -12,7 +12,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	var $test_args = array(
+	public $test_args = array(
 		'name'  => 'testname',
 		'value' => 'testvalue'
 	);


### PR DESCRIPTION
The default visibility is `public`, so for those methods and properties where the visibility was missing, I've elected to set them all to `public` so as not to break backward-compatibility.