### PR TITLE
CS: Move multi-line parameters out of function calls

### DIFF
--- a/admin/class-clicky-options-admin.php
+++ b/admin/class-clicky-options-admin.php
@@ -50,10 +50,18 @@ class Clicky_Options_Admin extends Clicky_Options {
 			'admin_site_key' => __( 'Admin Site Key', 'clicky' ),
 		);
 		foreach ( $clicky_settings as $key => $label ) {
-			add_settings_field( $key, $label, array( $this, 'input_text' ), 'clicky', 'basic-settings', array(
+			$args = array(
 				'name'  => 'clicky[' . $key . ']',
 				'value' => $this->options[ $key ],
-			) );
+			);
+			add_settings_field(
+				$key,
+				$label,
+				array( $this, 'input_text' ),
+				'clicky',
+				'basic-settings',
+				$args
+			);
 		}
 
 		add_settings_section( 'clicky-like', __( 'Like this plugin?', 'clicky' ), array(
@@ -91,14 +99,19 @@ class Clicky_Options_Admin extends Clicky_Options {
 			),
 		);
 		foreach ( $advanced_settings as $key => $arr ) {
-			add_settings_field( $key, $arr['label'], array(
-				$this,
-				'input_checkbox',
-			), 'clicky-advanced', 'clicky-advanced', array(
+			$args = array(
 				'name'  => $key,
 				'value' => isset( $this->options[ $key ] ) ? $this->options[ $key ] : false,
 				'desc'  => isset( $arr['desc'] ) ? $arr['desc'] : '',
-			) );
+			);
+			add_settings_field(
+				$key,
+				$arr['label'],
+				array( $this, 'input_checkbox' ),
+				'clicky-advanced',
+				'clicky-advanced',
+				$args
+			);
 		}
 	}
 
@@ -108,11 +121,19 @@ class Clicky_Options_Admin extends Clicky_Options {
 	private function register_outbound_settings() {
 		add_settings_section( 'clicky-outbound', __( 'Outbound Links', 'clicky' ), array( $this, 'outbound_explanation' ), 'clicky-advanced' );
 
-		add_settings_field( 'outbound_pattern', __( 'Outbound Link Pattern', 'clicky' ), array( $this, 'input_text' ), 'clicky-advanced', 'clicky-outbound', array(
+		$args = array(
 			'name'  => 'clicky[outbound_pattern]',
 			'value' => $this->options['outbound_pattern'],
 			'desc'  => __( 'For instance: <code>/out/,/go/</code>', 'clicky' ),
-		) );
+		);
+		add_settings_field(
+			'outbound_pattern',
+			__( 'Outbound Link Pattern', 'clicky' ),
+			array( $this, 'input_text' ),
+			'clicky-advanced',
+			'clicky-outbound',
+			$args
+		);
 	}
 
 	/**


### PR DESCRIPTION
WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.