### PR TITLE
CS: Use strict comparisons

### DIFF
--- a/frontend/class-clicky-frontend.php
+++ b/frontend/class-clicky-frontend.php
@@ -86,14 +86,14 @@ class Clicky_Frontend {
 	 * @return string
 	 */
 	private function outbound_tracking() {
-		if ( isset( $this->options['outbound_pattern'] ) && trim( $this->options['outbound_pattern'] ) != '' ) {
+		if ( isset( $this->options['outbound_pattern'] ) && trim( $this->options['outbound_pattern'] ) !== '' ) {
 
 			$patterns = preg_replace( '~[^\/a-zA-Z0-9,]+~', '', $this->options['outbound_pattern'] );
 
 			$patterns = explode( ',', $patterns );
 			$pattern  = '';
 			foreach ( $patterns as $pat ) {
-				if ( $pattern != '' ) {
+				if ( $pattern !== '' ) {
 					$pattern .= ',';
 				}
 				$pat = trim( str_replace( '"', '', str_replace( "'", '', $pat ) ) );
@@ -127,10 +127,10 @@ class Clicky_Frontend {
 	 */
 	public function track_comment( $commentID, $comment_status ) {
 		// Make sure to only track the comment if it's not spam (but do it for moderated comments).
-		if ( $comment_status != 'spam' ) {
+		if ( $comment_status !== 'spam' ) {
 			$comment = get_comment( $commentID );
 			// Only do this for normal comments, not for pingbacks or trackbacks.
-			if ( $comment->comment_type != 'pingback' && $comment->comment_type != 'trackback' ) {
+			if ( $comment->comment_type !== 'pingback' && $comment->comment_type !== 'trackback' ) {
 				$args   = array(
 					'type'       => 'click',
 					'href'       => '/wp-comments-post.php',

--- a/frontend/class-clicky-visitor-graph.php
+++ b/frontend/class-clicky-visitor-graph.php
@@ -177,7 +177,7 @@ class Clicky_Visitor_Graph {
 
 		$resp = wp_remote_get( $url );
 
-		if ( is_wp_error( $resp ) || ! isset( $resp['response']['code'] ) || $resp['response']['code'] != 200 ) {
+		if ( is_wp_error( $resp ) || ! isset( $resp['response']['code'] ) || (int) $resp['response']['code'] !== 200 ) {
 			return false;
 		}
 

--- a/tests/test-class-clicky-options.php
+++ b/tests/test-class-clicky-options.php
@@ -15,13 +15,13 @@ class Clicky_Options_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Options::get
 	 */
 	public function test_get() {
-		$this->assertTrue( self::$class_instance->get() == Clicky_Options::$option_defaults );
+		$this->assertTrue( self::$class_instance->get() === Clicky_Options::$option_defaults );
 	}
 
 	/**
 	 * @covers Clicky_Options::__construct
 	 */
 	public function test___construct() {
-		$this->assertTrue( self::$class_instance->options == Clicky_Options::$option_defaults );
+		$this->assertTrue( self::$class_instance->options === Clicky_Options::$option_defaults );
 	}
 }


### PR DESCRIPTION
Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

This is especially important when comparing variables which are expected to be strings, as when one of the two operands - for whatever reason, other plugins interfering, errors etc - is not a string, the other operand will be juggled to the type of the first operand which can lead to unexpected results and hard to debug bugs.

Ref: http://phpcheatsheets.com/compare/equal/