### PR TITLE
CS: fix formatting of embedded PHP

### DIFF
--- a/admin/views/meta-box.php
+++ b/admin/views/meta-box.php
@@ -4,8 +4,14 @@
  */
 
 ?><p>
-	<?php printf( __( 'Clicky can track Goals for you too, %1$syou can create them here%2$s. To be able to track a goal on this post, you need to specify the goal ID here.
-    Optionally, you can also provide the goal revenue.', 'clicky' ), '<a target="_blank" href="https://clicky.com/stats/goals-setup?site_id=' . $this->options['site_id'] . '">', '</a>' ); ?>
+	<?php
+	printf(
+		/* translators: 1: link open tag to clicky website tracking page; 2: link close tag. */
+		__( 'Clicky can track Goals for you too, %1$syou can create them here%2$s. To be able to track a goal on this post, you need to specify the goal ID here. Optionally, you can also provide the goal revenue.', 'clicky' ),
+		'<a target="_blank" href="https://clicky.com/stats/goals-setup?site_id=' . $this->options['site_id'] . '">',
+		'</a>'
+	);
+	?>
 </p>
 <table>
 	<tr>


### PR DESCRIPTION
Now, there are a couple of things fixed in one go here.

To start, the phrase contains placeholders and therefore needs a translators comment.
To add the translators comment, the embedded PHP would become multi-line (well, it already was, but shouldn't have been).
When embedded PHP is multi-line, the PHP open and close tags should each be on their own line without any other content.
And as the snippet now has become a multi-line snippet anyway, we may as well make the function call more readable by making it a proper multi-line function call.

Lastly, the phrase contained a new line character. These are meaningless in .po files and confusing for translators - should this be a `<br>` ?, does the format matter ? -, so this new line character has been removed.