### PR TITLE
CS/QA: review of all include and require statements

### DIFF
--- a/admin/class-clicky-admin-page.php
+++ b/admin/class-clicky-admin-page.php
@@ -51,7 +51,7 @@ class Clicky_Admin_Page extends Clicky_Admin {
 	 * Creates the configuration page
 	 */
 	public function config_page() {
-		require 'views/admin-page.php';
+		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/admin-page.php';
 	}
 
 	/**
@@ -80,7 +80,7 @@ class Clicky_Admin_Page extends Clicky_Admin {
 	 * @param string $extra_links Additional links to add to the output, after the RSS subscribe link.
 	 */
 	private function rss_news( $feed, $title, $extra_links = '' ) {
-		include_once( ABSPATH . WPINC . '/feed.php' );
+		include_once ABSPATH . WPINC . '/feed.php';
 		$rss = fetch_feed( $feed );
 
 		if ( is_wp_error( $rss ) ) {

--- a/admin/class-clicky-admin.php
+++ b/admin/class-clicky-admin.php
@@ -122,7 +122,7 @@ class Clicky_Admin {
 
 		$clicky_goal = get_post_meta( $post->ID, '_clicky_goal', true );
 
-		require 'views/meta-box.php';
+		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/meta-box.php';
 	}
 
 	/**
@@ -148,7 +148,7 @@ class Clicky_Admin {
 		);
 		$iframe_url = 'https://clicky.com/stats/wp-iframe?' . http_build_query( $args, '', '&amp;' );
 
-		require 'views/stats-page.php';
+		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/stats-page.php';
 	}
 
 	/**

--- a/admin/class-clicky-options-admin.php
+++ b/admin/class-clicky-options-admin.php
@@ -119,7 +119,7 @@ class Clicky_Options_Admin extends Clicky_Options {
 	 * Create a "plugin like" box.
 	 */
 	public function like_text() {
-		require 'views/like-box.php';
+		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/like-box.php';
 	}
 
 	/**

--- a/frontend/class-clicky-frontend.php
+++ b/frontend/class-clicky-frontend.php
@@ -47,14 +47,14 @@ class Clicky_Frontend {
 		}
 
 		if ( $this->options['track_names'] ) {
-			require 'views/comment-author-script.php';
+			require CLICKY_PLUGIN_DIR_PATH . 'admin/views/comment-author-script.php';
 		}
 
 		$clicky_extra  = $this->goal_tracking();
 		$clicky_extra .= $this->outbound_tracking();
 		$clicky_extra .= $this->disable_cookies();
 
-		require 'views/script.php';
+		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/script.php';
 	}
 
 	/**

--- a/tests/test-class-clicky-admin.php
+++ b/tests/test-class-clicky-admin.php
@@ -80,7 +80,7 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 		update_post_meta( $post_id, '_clicky_goal', $clicky_goal );
 
 		ob_start();
-		require( 'admin/views/meta-box.php' );
+		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/meta-box.php';
 		$output = ob_get_clean();
 
 		$this->expectOutputString( $output );

--- a/tests/test-class-clicky-options-admin.php
+++ b/tests/test-class-clicky-options-admin.php
@@ -46,7 +46,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 	 */
 	public function test_like_text() {
 		ob_start();
-		require( 'admin/views/like-box.php' );
+		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/like-box.php';
 		$output = ob_get_clean();
 
 		$this->expectOutputString( $output );


### PR DESCRIPTION
`include` and `require` are language constructs, not functions.

With that in mind there are a number of best practices surrounding them:
* There is no need to use parenthesis and not doing so will be, albeit marginally, faster.
* Always pass an absolute path for maximum portability. The `clicky.php` file defines the `CLICKY_PLUGIN_DIR_PATH` constant to be used for that (includes trailing slash), WP itself has `ABSPATH` (includes trailing slash).
    ~~The Clicky unit tests did not have a good constant available for this so far, this has been fixed by adding a `CLICKY_TESTS_PATH` constant (including trailing slash) to the `bootstrap.php` file.~~ _(removed, superseded by another commit making this unnecessary)_
* As all the relevant PATH constants already contain a trailing slash, there is no need for a slash at the start of the text string pointing to the exact file to be included.

Suggested additional review to be done (by team Yoast):
* Check whether the correct file inclusion structure is being used, i.e. `include(_once)` versus `require(_once)`.
    Most of the time, `require(_once)` is the better structure to use, but this does need to be reviewed on an individual basis.
    For input on the considerations to take into account during this review, see  WordPress-Coding-Standards/WordPress-Coding-Standards#1143