### PR TITLE
QA: fix the link to the plugin in various places

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ WordPress plugin for Clicky.com Analytics
 Welcome to the Clicky for WordPress Github repository
 -----------------------------------------------------
 
-While the documentation for the [Clicky for WordPress plugin](https://yoast.com/wordpress/plugins/clicky/) can be found on yoast.com, here
+While the documentation for the [Clicky for WordPress plugin](https://yoast.com/wordpress/plugins/clicky-2/) can be found on yoast.com, here
 you can browse the source of the project, find and discuss open issues and even
 [contribute yourself](https://github.com/Yoast/clicky/blob/trunk/CONTRIBUTING.md).
 
 Installation
 ------------
 
-Here's a [guide on how to install Clicky in your WordPress site](https://yoast.com/wordpress/plugins/clicky/).
+Here's a [guide on how to install Clicky in your WordPress site](https://yoast.com/wordpress/plugins/clicky-2/).
 If you want to run the Git version though, you have two options:
 
 * You can clone the GitHub repository: https://github.com/Yoast/clicky.git

--- a/clicky.php
+++ b/clicky.php
@@ -4,7 +4,7 @@
  *
  * Plugin Name: Clicky for WordPress
  * Version: 1.7
- * Plugin URI: https://yoast.com/wordpress/plugins/clicky/
+ * Plugin URI: https://yoast.com/wordpress/plugins/clicky-2/
  * Description: The Clicky for WordPress plugin by Yoast makes it easy for you to add your Clicky analytics tracking code to your WordPress install, while also giving you some advanced tracking options.
  * Author: Team Yoast
  * Author URI: https://yoast.com/

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "tracking",
     "clicky"
   ],
-  "homepage": "https://yoast.com/wordpress/plugins/clicky/",
+  "homepage": "https://yoast.com/wordpress/plugins/clicky-2/",
   "license": "GPL-2.0-or-later",
   "authors": [
     {


### PR DESCRIPTION
While the old link redirects, using the direct link should be preferred.