### PR TITLE
Travis: _do_ build the dev branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 branches:
   only:
     - master
-    - trunk
+    - develop
     - /^release\/\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^hotfix\/\d+\.\d+(\.\d+)?(-\S*)?$/
 


### PR DESCRIPTION
... of course, this repo uses `develop`, not `trunk` as the name for the `dev` branch, so let's fix that.