### PR TITLE
CS: Each parameter should start on a new line in multi-line function calls

### DIFF
--- a/admin/class-clicky-admin.php
+++ b/admin/class-clicky-admin.php
@@ -49,10 +49,13 @@ class Clicky_Admin {
 		$public_post_types = get_post_types( array( 'public' => true ) );
 
 		foreach ( $public_post_types as $post_type ) {
-			add_meta_box( 'clicky', __( 'Clicky Goal Tracking', 'clicky' ), array(
-				$this,
-				'meta_box_content',
-			), $post_type, 'side' );
+			add_meta_box(
+				'clicky',
+				__( 'Clicky Goal Tracking', 'clicky' ),
+				array( $this, 'meta_box_content' ),
+				$post_type,
+				'side'
+			);
 		}
 
 		$this->register_menu_pages();
@@ -65,14 +68,21 @@ class Clicky_Admin {
 	 * @link https://codex.wordpress.org/Function_Reference/add_dashboard_page
 	 */
 	private function register_menu_pages() {
-		add_options_page( __( 'Clicky settings', 'clicky' ), __( 'Clicky', 'clicky' ), 'manage_options', $this->hook, array(
-			new Clicky_Admin_Page(),
-			'config_page',
-		) );
-		add_dashboard_page( __( 'Clicky Stats', 'clicky' ), __( 'Clicky Stats', 'clicky' ), 'manage_options', 'clicky_stats', array(
-			$this,
-			'dashboard_page',
-		) );
+		add_options_page(
+			__( 'Clicky settings', 'clicky' ),
+			__( 'Clicky', 'clicky' ),
+			'manage_options',
+			$this->hook,
+			array( new Clicky_Admin_Page(), 'config_page' )
+		);
+
+		add_dashboard_page(
+			__( 'Clicky Stats', 'clicky' ),
+			__( 'Clicky Stats', 'clicky' ),
+			'manage_options',
+			'clicky_stats',
+			array( $this, 'dashboard_page' )
+		);
 	}
 
 	/**

--- a/admin/class-clicky-options-admin.php
+++ b/admin/class-clicky-options-admin.php
@@ -41,10 +41,12 @@ class Clicky_Options_Admin extends Clicky_Options {
 	 * Register the basic settings
 	 */
 	private function register_basic_settings() {
-		add_settings_section( 'basic-settings', __( 'Basic settings', 'clicky' ), array(
-			$this,
-			'basic_settings_intro',
-		), 'clicky' );
+		add_settings_section(
+			'basic-settings',
+			__( 'Basic settings', 'clicky' ),
+			array( $this, 'basic_settings_intro' ),
+			'clicky'
+		);
 
 		$clicky_settings = array(
 			'site_id'        => __( 'Site ID', 'clicky' ),
@@ -66,15 +68,19 @@ class Clicky_Options_Admin extends Clicky_Options {
 			);
 		}
 
-		add_settings_section( 'clicky-like', __( 'Like this plugin?', 'clicky' ), array(
-			$this,
-			'like_text',
-		), 'clicky' );
+		add_settings_section(
+			'clicky-like',
+			__( 'Like this plugin?', 'clicky' ),
+			array( $this, 'like_text' ),
+			'clicky'
+		);
 
-		add_settings_section( 'clicky-support', __( 'Need support?', 'clicky' ), array(
-			$this,
-			'support_text',
-		), 'clicky' );
+		add_settings_section(
+			'clicky-support',
+			__( 'Need support?', 'clicky' ),
+			array( $this, 'support_text' ),
+			'clicky'
+		);
 	}
 
 	/**
@@ -121,7 +127,12 @@ class Clicky_Options_Admin extends Clicky_Options {
 	 * Register the outbound links settings section
 	 */
 	private function register_outbound_settings() {
-		add_settings_section( 'clicky-outbound', __( 'Outbound Links', 'clicky' ), array( $this, 'outbound_explanation' ), 'clicky-advanced' );
+		add_settings_section(
+			'clicky-outbound',
+			__( 'Outbound Links', 'clicky' ),
+			array( $this, 'outbound_explanation' ),
+			'clicky-advanced'
+		);
 
 		$args = array(
 			'name'  => 'clicky[outbound_pattern]',


### PR DESCRIPTION
WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1330

This commit addresses multi-line function calls where parameters did not each start on a new line.

Also note that non-associative arrays don't have to be multi-line and - especially for call-backs - using single-line format can improve the readability of the code.