### PR TITLE
CS: Use a single line for function call-back arrays as function call parameters

### DIFF
--- a/tests/test-class-clicky-admin.php
+++ b/tests/test-class-clicky-admin.php
@@ -22,10 +22,7 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 	public function test___construct() {
 		$this->assertEquals( self::$class_instance->options, Clicky_Options::$option_defaults );
 
-		$this->assertEquals( 10, has_filter( 'plugin_action_links', array(
-			self::$class_instance,
-			'add_action_link',
-		) ) );
+		$this->assertEquals( 10, has_filter( 'plugin_action_links', array( self::$class_instance, 'add_action_link' ) ) );
 
 		$this->assertEquals( 10, has_action( 'publish_post', array( self::$class_instance, 'insert_post' ) ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', array( self::$class_instance, 'admin_warnings' ) ) );


### PR DESCRIPTION
WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the first variant.