### PR TITLE
CS/XSS: always escape output [4]

### DIFF
--- a/admin/class-clicky-admin.php
+++ b/admin/class-clicky-admin.php
@@ -149,7 +149,7 @@ class Clicky_Admin {
 			'site_id' => $this->options['site_id'],
 			'sitekey' => $this->options['site_key'],
 		);
-		$iframe_url = 'https://clicky.com/stats/wp-iframe?' . http_build_query( $args, '', '&amp;' );
+		$iframe_url = add_query_arg( $args, 'https://clicky.com/stats/wp-iframe?' );
 
 		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/stats-page.php';
 	}

--- a/admin/views/stats-page.php
+++ b/admin/views/stats-page.php
@@ -7,4 +7,4 @@
 
 ?><br/>
 <iframe style="margin-left: 20px; width: 100%; height: 1000px;"
-		src="<?php echo $iframe_url; ?>"></iframe>
+		src="<?php echo esc_url( $iframe_url ); ?>"></iframe>

--- a/tests/test-class-clicky-admin.php
+++ b/tests/test-class-clicky-admin.php
@@ -119,7 +119,7 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 
 		$expected = '<br/>
 <iframe style="margin-left: 20px; width: 100%; height: 1000px;"
-		src="https://clicky.com/stats/wp-iframe?site_id=1&amp;sitekey=2"></iframe>
+		src="https://clicky.com/stats/wp-iframe?site_id=1&#038;sitekey=2"></iframe>
 ';
 
 		$this->expectOutputString( $expected );


### PR DESCRIPTION
A little more involved change.

* Use the WP native `add_query_arg()` function rather than the PHP native `http_build_query()`.
* Escape the URL in the HTML output.
* Adjust the unit test to reflect the updated code.