### PR TITLE
QA: don't use readfile unnecessarily

### DIFF
--- a/frontend/class-clicky-visitor-graph.php
+++ b/frontend/class-clicky-visitor-graph.php
@@ -109,7 +109,7 @@ class Clicky_Visitor_Graph {
 
 		echo "\n";
 		echo "<style type='text/css'>\n";
-		readfile( CLICKY_PLUGIN_DIR_PATH . '/css/adminbar' . $ext );
+		include CLICKY_PLUGIN_DIR_PATH . '/css/adminbar' . $ext;
 		echo "\n";
 		echo "</style>\n";
 	}


### PR DESCRIPTION
Using a simple `include` will have the same effect.