### PR TITLE
CS/XSS: always escape output [3]

### DIFF
--- a/admin/class-clicky-admin-page.php
+++ b/admin/class-clicky-admin-page.php
@@ -97,7 +97,7 @@ class Clicky_Admin_Page extends Clicky_Admin {
 			foreach ( $rss_items as $item ) {
 				$url  = preg_replace( '/#.*/', '', esc_url( $item->get_permalink(), $protocolls = null, 'display' ) );
 				$rss .= '<li class="yoast">';
-				$rss .= '<a href="' . $url . '#utm_source=wpadmin&utm_medium=sidebarwidget&utm_term=newsitem&utm_campaign=clickywpplugin">' . $item->get_title() . '</a> ';
+				$rss .= '<a href="' . esc_url( $url . '#utm_source=wpadmin&utm_medium=sidebarwidget&utm_term=newsitem&utm_campaign=clickywpplugin' ) . '">' . $item->get_title() . '</a> ';
 				$rss .= '</li>';
 			}
 		}

--- a/admin/views/admin-page.php
+++ b/admin/views/admin-page.php
@@ -7,7 +7,7 @@
 
 ?><div class="wrap">
 	<h2>
-		<img id="plugin_icon" src="<?php echo esc_url( CLICKY_PLUGIN_DIR_URL ); ?>images/clicky-32x32.png" class="alignleft" /> Clicky <?php esc_html_e( 'Configuration', 'clicky' ); ?>
+		<img id="plugin_icon" src="<?php echo esc_url( CLICKY_PLUGIN_DIR_URL . 'images/clicky-32x32.png' ); ?>" class="alignleft" /> Clicky <?php esc_html_e( 'Configuration', 'clicky' ); ?>
 	</h2>
 
 	<form action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>" method="post">

--- a/admin/views/meta-box.php
+++ b/admin/views/meta-box.php
@@ -10,7 +10,7 @@
 	printf(
 		/* translators: 1: link open tag to clicky website tracking page; 2: link close tag. */
 		esc_html__( 'Clicky can track Goals for you too, %1$syou can create them here%2$s. To be able to track a goal on this post, you need to specify the goal ID here. Optionally, you can also provide the goal revenue.', 'clicky' ),
-		'<a target="_blank" href="https://clicky.com/stats/goals-setup?site_id=' . esc_attr( $this->options['site_id'] ) . '">',
+		'<a target="_blank" href="' . esc_url( 'https://clicky.com/stats/goals-setup?site_id=' . $this->options['site_id'] ) . '">',
 		'</a>'
 	);
 	?>


### PR DESCRIPTION
When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.