### PR TITLE
CS/XSS: always escape output [5]

### DIFF
--- a/frontend/views/comment-author-script.php
+++ b/frontend/views/comment-author-script.php
@@ -16,6 +16,6 @@
 		}
 		return '';
 	}
-	var username_check = clicky_gc('comment_author_<?php echo esc_attr( md5( get_option( 'siteurl' ) ) ); ?>');
+	var username_check = clicky_gc('<?php echo wp_json_encode( 'comment_author_' . md5( get_option( 'siteurl' ) ) ); ?>');
 	if (username_check) var clicky_custom_session = {username: username_check};
 </script>

--- a/frontend/views/script.php
+++ b/frontend/views/script.php
@@ -16,7 +16,7 @@
 	?>
 
 	var clicky_site_ids = clicky_site_ids || [];
-	clicky_site_ids.push(<?php echo esc_attr( $this->options['site_id'] ); ?>);
+	clicky_site_ids.push(<?php echo wp_json_encode( $this->options['site_id'] ); ?>);
 </script>
 <?php
 // @codingStandardsIgnoreLine WordPress.WP.EnqueuedResources.NonEnqueuedScript


### PR DESCRIPTION
The correct way to escape variable data within a javascript snippet is to use `wp_json_encode()`.

Also see: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1270

### Testing

This is a functional change. The change has not been tested (yet).
While I expect no problems, testing the change is recommended.