### PR TITLE
CS: use cast rather than function call

### DIFF
--- a/admin/class-clicky-admin.php
+++ b/admin/class-clicky-admin.php
@@ -150,7 +150,7 @@ class Clicky_Admin {
 	public function insert_post( $post_id ) {
 		$clicky_goal = array(
 			'id'    => (int) filter_input( INPUT_POST, 'clicky_goal_id' ),
-			'value' => floatval( filter_input( INPUT_POST, 'clicky_goal_value' ) ),
+			'value' => (float) filter_input( INPUT_POST, 'clicky_goal_value' ),
 		);
 		update_post_meta( $post_id, '_clicky_goal', $clicky_goal );
 	}


### PR DESCRIPTION
`floatval` is mostly intended to be used with call-backs.
For an ordinary cast-to-float, using a type cast is more performant than using the function call.

### Testing

This is a code-only change and should be safe to merge without testing.