### PR TITLE
CS/QA: load scripts in a non-blocking way

### DIFF
--- a/admin/class-clicky-admin-page.php
+++ b/admin/class-clicky-admin-page.php
@@ -35,7 +35,7 @@ class Clicky_Admin_Page extends Clicky_Admin {
 	 * Enqueue the scripts for the admin page.
 	 */
 	public function config_page_scripts() {
-		wp_enqueue_script( 'clicky-admin-js', CLICKY_PLUGIN_DIR_URL . 'js/admin.min.js', null, CLICKY_PLUGIN_VERSION );
+		wp_enqueue_script( 'clicky-admin-js', CLICKY_PLUGIN_DIR_URL . 'js/admin.min.js', null, CLICKY_PLUGIN_VERSION, true );
 	}
 
 	/**


### PR DESCRIPTION
Loading scripts in the page footer instead of in the page header means that they will not block the rendering of the page while loading.

### Testing

This is a functional change. The change has not been tested (yet).
While I expect no problems, testing the change is recommended.