### PR TITLE
Travis: bring versions in line with minimum supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - php: 7.0
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: 5.6
-      env: WP_VERSION=5.0 WP_MULTISITE=0
+      env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: 5.2
       dist: precise
       env: PHPLINT=1 WP_VERSION=5.1 WP_MULTISITE=0


### PR DESCRIPTION
The minimum supported WP version was updated to WP 5.1 in 3bdeb47afc7c5571c7a7d94f6623ff70e7f28e1b, but WP 5.0 was still being used in the Travis script.