### PR TITLE
QA: use the most specific PHPUnit assertion possible

### DIFF
--- a/tests/framework/class-clicky-unit-test-case.php
+++ b/tests/framework/class-clicky-unit-test-case.php
@@ -24,6 +24,6 @@ class Clicky_UnitTestCase extends WP_UnitTestCase {
 	protected function expectOutput( $string, $function = null ) {
 		$output = ob_get_contents();
 		ob_clean();
-		$this->assertEquals( $output, $string );
+		$this->assertSame( $output, $string );
 	}
 }

--- a/tests/test-class-clicky-admin-page.php
+++ b/tests/test-class-clicky-admin-page.php
@@ -28,17 +28,17 @@ class Clicky_Admin_Page_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Admin_Page::__construct
 	 */
 	public function test___construct() {
-		$this->assertEquals( self::$class_instance->options, Clicky_Options::$option_defaults );
+		$this->assertSame( self::$class_instance->options, Clicky_Options::$option_defaults );
 
-		$this->assertEquals( 10, has_action( 'admin_print_scripts', array( self::$class_instance, 'config_page_scripts' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_print_styles', array( self::$class_instance, 'config_page_styles' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_head', array( self::$class_instance, 'i18n_module' ) ) );
+		$this->assertSame( 10, has_action( 'admin_print_scripts', array( self::$class_instance, 'config_page_scripts' ) ) );
+		$this->assertSame( 10, has_action( 'admin_print_styles', array( self::$class_instance, 'config_page_styles' ) ) );
+		$this->assertSame( 10, has_action( 'admin_head', array( self::$class_instance, 'i18n_module' ) ) );
 	}
 
 	public function test_config_page_styles() {
 		self::$class_instance->config_page_styles();
 
 		global $wp_styles;
-		$this->assertEquals( 'clicky-admin-css', $wp_styles->registered['clicky-admin-css']->handle );
+		$this->assertSame( 'clicky-admin-css', $wp_styles->registered['clicky-admin-css']->handle );
 	}
 }

--- a/tests/test-class-clicky-admin.php
+++ b/tests/test-class-clicky-admin.php
@@ -28,13 +28,13 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Admin::__construct
 	 */
 	public function test___construct() {
-		$this->assertEquals( self::$class_instance->options, Clicky_Options::$option_defaults );
+		$this->assertSame( self::$class_instance->options, Clicky_Options::$option_defaults );
 
-		$this->assertEquals( 10, has_filter( 'plugin_action_links', array( self::$class_instance, 'add_action_link' ) ) );
+		$this->assertSame( 10, has_filter( 'plugin_action_links', array( self::$class_instance, 'add_action_link' ) ) );
 
-		$this->assertEquals( 10, has_action( 'publish_post', array( self::$class_instance, 'insert_post' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_notices', array( self::$class_instance, 'admin_warnings' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_menu', array( self::$class_instance, 'admin_init' ) ) );
+		$this->assertSame( 10, has_action( 'publish_post', array( self::$class_instance, 'insert_post' ) ) );
+		$this->assertSame( 10, has_action( 'admin_notices', array( self::$class_instance, 'admin_warnings' ) ) );
+		$this->assertSame( 10, has_action( 'admin_menu', array( self::$class_instance, 'admin_init' ) ) );
 	}
 
 	/**
@@ -45,8 +45,8 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 		self::$class_instance->admin_init();
 
 		global $wp_meta_boxes;
-		$this->assertEquals( 'clicky', $wp_meta_boxes['post']['side']['default']['clicky']['id'] );
-		$this->assertEquals( 'clicky', $wp_meta_boxes['page']['side']['default']['clicky']['id'] );
+		$this->assertSame( 'clicky', $wp_meta_boxes['post']['side']['default']['clicky']['id'] );
+		$this->assertSame( 'clicky', $wp_meta_boxes['page']['side']['default']['clicky']['id'] );
 	}
 
 	/**
@@ -112,7 +112,7 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 			'value' => 0.0,
 		);
 
-		$this->assertEquals( $expected, $goal );
+		$this->assertSame( $expected, $goal );
 	}
 
 	/**
@@ -139,6 +139,6 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 		$output   = self::$class_instance->add_action_link( array(), CLICKY_PLUGIN_FILE );
 		$expected = '<a href="' . admin_url( 'options-general.php?page=clicky' ) . '">Settings</a>';
 
-		$this->assertEquals( $expected, $output[0] );
+		$this->assertSame( $expected, $output[0] );
 	}
 }

--- a/tests/test-class-clicky-options-admin.php
+++ b/tests/test-class-clicky-options-admin.php
@@ -38,7 +38,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Options_Admin::__construct
 	 */
 	public function test___construct() {
-		$this->assertEquals( self::$class_instance->options, Clicky_Options::$option_defaults );
+		$this->assertSame( self::$class_instance->options, Clicky_Options::$option_defaults );
 	}
 
 	/**
@@ -50,8 +50,8 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 
 		global $wp_settings_sections, $wp_settings_fields;
 
-		$this->assertTrue( array_key_exists( 'clicky', $wp_settings_sections ) );
-		$this->assertTrue( array_key_exists( 'clicky', $wp_settings_fields ) );
+		$this->assertArrayHasKey( 'clicky', $wp_settings_sections );
+		$this->assertArrayHasKey( 'clicky', $wp_settings_fields );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 		self::$class_instance->basic_settings_intro();
 		$output = ob_get_clean();
 
-		$this->assertTrue( strlen( $output ) > 0 );
+		$this->assertGreaterThan( 0, strlen( $output ) );
 		$this->assertTrue( is_int( strpos( $output, '//clicky.com/145844' ) ) );
 	}
 
@@ -90,7 +90,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 		self::$class_instance->outbound_explanation();
 		$output = ob_get_clean();
 
-		$this->assertTrue( strlen( $output ) > 0 );
+		$this->assertGreaterThan( 0, strlen( $output ) );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 		self::$class_instance->support_text();
 		$output = ob_get_clean();
 
-		$this->assertTrue( strlen( $output ) > 0 );
+		$this->assertGreaterThan( 0, strlen( $output ) );
 		$this->assertTrue( is_int( strpos( $output, 'clicky.com/forums' ) ) );
 	}
 

--- a/tests/test-class-clicky-options.php
+++ b/tests/test-class-clicky-options.php
@@ -28,13 +28,13 @@ class Clicky_Options_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Options::get
 	 */
 	public function test_get() {
-		$this->assertTrue( self::$class_instance->get() === Clicky_Options::$option_defaults );
+		$this->assertSame( self::$class_instance->get(), Clicky_Options::$option_defaults );
 	}
 
 	/**
 	 * @covers Clicky_Options::__construct
 	 */
 	public function test___construct() {
-		$this->assertTrue( self::$class_instance->options === Clicky_Options::$option_defaults );
+		$this->assertSame( self::$class_instance->options, Clicky_Options::$option_defaults );
 	}
 }


### PR DESCRIPTION
This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available has been extended hugely over the years.

To have the most reliable tests, the most specific assertion should be used.

This implements this for the Clicky plugin, while keeping in mind that at this time, PHPUnit 4.x should still be supported.

Refs:
* https://phpunit.de/manual/4.8/en/appendixes.assertions.html
* https://phpunit.readthedocs.io/en/7.5/assertions.html#

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame