### PR TITLE
QA: Unit tests: use the correct parameter order

### DIFF
--- a/tests/framework/class-clicky-unit-test-case.php
+++ b/tests/framework/class-clicky-unit-test-case.php
@@ -24,6 +24,6 @@ class Clicky_UnitTestCase extends WP_UnitTestCase {
 	protected function expectOutput( $string, $function = null ) {
 		$output = ob_get_contents();
 		ob_clean();
-		$this->assertSame( $output, $string );
+		$this->assertSame( $string, $output );
 	}
 }

--- a/tests/test-class-clicky-admin-page.php
+++ b/tests/test-class-clicky-admin-page.php
@@ -28,7 +28,7 @@ class Clicky_Admin_Page_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Admin_Page::__construct
 	 */
 	public function test___construct() {
-		$this->assertSame( self::$class_instance->options, Clicky_Options::$option_defaults );
+		$this->assertSame( Clicky_Options::$option_defaults, self::$class_instance->options );
 
 		$this->assertSame( 10, has_action( 'admin_print_scripts', array( self::$class_instance, 'config_page_scripts' ) ) );
 		$this->assertSame( 10, has_action( 'admin_print_styles', array( self::$class_instance, 'config_page_styles' ) ) );

--- a/tests/test-class-clicky-admin.php
+++ b/tests/test-class-clicky-admin.php
@@ -28,7 +28,7 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Admin::__construct
 	 */
 	public function test___construct() {
-		$this->assertSame( self::$class_instance->options, Clicky_Options::$option_defaults );
+		$this->assertSame( Clicky_Options::$option_defaults, self::$class_instance->options );
 
 		$this->assertSame( 10, has_filter( 'plugin_action_links', array( self::$class_instance, 'add_action_link' ) ) );
 

--- a/tests/test-class-clicky-options-admin.php
+++ b/tests/test-class-clicky-options-admin.php
@@ -38,7 +38,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Options_Admin::__construct
 	 */
 	public function test___construct() {
-		$this->assertSame( self::$class_instance->options, Clicky_Options::$option_defaults );
+		$this->assertSame( Clicky_Options::$option_defaults, self::$class_instance->options );
 	}
 
 	/**

--- a/tests/test-class-clicky-options.php
+++ b/tests/test-class-clicky-options.php
@@ -28,13 +28,13 @@ class Clicky_Options_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Options::get
 	 */
 	public function test_get() {
-		$this->assertSame( self::$class_instance->get(), Clicky_Options::$option_defaults );
+		$this->assertSame( Clicky_Options::$option_defaults, self::$class_instance->get() );
 	}
 
 	/**
 	 * @covers Clicky_Options::__construct
 	 */
 	public function test___construct() {
-		$this->assertSame( self::$class_instance->options, Clicky_Options::$option_defaults );
+		$this->assertSame( Clicky_Options::$option_defaults, self::$class_instance->options );
 	}
 }


### PR DESCRIPTION
For PHPUnit assertions which expect an `$expected` and a `$result` parameter, the parameter order is always `( $expected, $result, ...).

While it may not seem important to use the correct parameter order for assertions doing a straight comparison, in actual fact, it is.
The PHPUnit output when the assertions fail expects this order and the failure message will be reversed if the parameters are passed in reversed order which leads to confusion and makes it more difficult to debug a failing test.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame