### PR TITLE
QA: Unit tests: use a more appropriate assertion

### DIFF
--- a/tests/test-class-clicky-options-admin.php
+++ b/tests/test-class-clicky-options-admin.php
@@ -77,7 +77,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertGreaterThan( 0, strlen( $output ) );
-		$this->assertTrue( is_int( strpos( $output, '//clicky.com/145844' ) ) );
+		$this->assertContains( '//clicky.com/145844', $output );
 	}
 
 	/**
@@ -104,7 +104,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertGreaterThan( 0, strlen( $output ) );
-		$this->assertTrue( is_int( strpos( $output, 'clicky.com/forums' ) ) );
+		$this->assertContains( 'clicky.com/forums', $output );
 	}
 
 	/**


### PR DESCRIPTION
`assertContains()` can be used to examine both arrays as well as strings.
When passed a string as the `$haystack`, it will examine it to see if the `$needle` exists in the string.

So, basically that function does the same as the current test was doing, but then using PHPUnit native assertions,

Ref:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertContains#appendixes.assertions.assertContains.example2