### PR TITLE
Stop explicit support for PHP < 5.6 / WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: trusty
-sudo: false
 
 cache:
   directories:
@@ -21,22 +20,21 @@ matrix:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=master WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CODE_CLIMATE=1 CODECLIMATE_REPO_TOKEN=33af926f948ae958e14a3ecdc85c24e16a42a91f2a57a9c59bfb118c71a971e2
+      env: WP_VERSION=master WP_MULTISITE=1 PHPCS=1 CODE_CLIMATE=1 CODECLIMATE_REPO_TOKEN=33af926f948ae958e14a3ecdc85c24e16a42a91f2a57a9c59bfb118c71a971e2
     - php: 7.2
-      env: WP_VERSION=5.1 WP_MULTISITE=0
-    - php: 7.0
-      env: WP_VERSION=5.2 WP_MULTISITE=1
-    - php: 5.6
       env: WP_VERSION=5.2 WP_MULTISITE=0
-    - php: 5.2
-      dist: precise
-      env: PHPLINT=1 WP_VERSION=5.1 WP_MULTISITE=0
+    - php: 7.0
+      env: WP_VERSION=5.3 WP_MULTISITE=0
+    - php: 5.6
+      env: PHPLINT=1 WP_VERSION=5.2 WP_MULTISITE=1
     - php: "7.4snapshot"
-      env: WP_VERSION=master WP_MULTISITE=0
+      env: PHPLINT=1 WP_VERSION=5.3 WP_MULTISITE=0
+    - php: "nightly"
+      env: PHPLINT=1
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
+    - php: "nightly"
 
 before_install:
 - if [[ "$CODE_CLIMATE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
@@ -44,27 +42,24 @@ before_install:
 
 install:
 - |
-  if [[ "$CODE_CLIMATE" == "1" || "$PHPCS" == "1" || ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
+  if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
     composer install --no-interaction
-  else
-    if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local 5.6.13; fi
-    composer install --no-dev --no-interaction
-    phpenv local --unset
   fi
 
 before_script:
-- bash tests/bin/before.sh $WP_VERSION
+- |
+  if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+    bash tests/bin/before.sh $WP_VERSION
+  fi
 
 script:
 - if [[ "$PHPLINT" == "1" ]]; then bash tests/bin/phplint.sh; fi
 - if [[ "$PHPCS" == "1" ]]; then composer check-cs;fi
 - |
   if [[ "$CODE_CLIMATE" == "1" ]]; then
-    vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-  elif [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-    vendor/bin/phpunit
-  else
-    phpunit
+    composer test -- --coverage-clover build/logs/clover.xml
+  elif [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+    composer test
   fi
 
 # Validate the composer.json file.

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   ],
   "type": "wordpress-plugin",
   "require": {
+    "php": ">=5.6",
     "composer/installers": "~1.0",
     "yoast/i18n-module": "^1.0",
     "xrstf/composer-php52": "^1.0"
@@ -23,7 +24,7 @@
   "require-dev": {
     "codeclimate/php-test-reporter": "dev-master",
     "yoast/yoastcs": "^1.3.0",
-    "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0"
+    "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0"
   },
   "autoload": {
     "classmap": [
@@ -42,6 +43,9 @@
     ],
     "fix-cs": [
       "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+    ],
+    "test": [
+      "@php ./vendor/phpunit/phpunit/phpunit"
     ],
     "post-install-cmd": [
       "xrstf\\Composer52\\Generator::onPostInstallCmd"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18258fceda6b27e57146c08d4017f659",
+    "content-hash": "ca8c94e1abf79c7e2bdac9880886ce30",
     "packages": [
         {
             "name": "composer/installers",
@@ -2805,6 +2805,8 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.6"
+    },
     "platform-dev": []
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,10 @@ Contributors: joostdevalk, yoast
 Tags: analytics, statistics, clicky, getclicky, affiliate, outbound links, analysis, Yoast
 Requires at least: 5.2
 Tested up to: 5.3
+License: GPLv2
+License URI: http://www.gnu.org/licenses/gpl.html
 Stable tag: 1.8
+Requires PHP: 5.6.20
 
 Integrates the Clicky web analytics service into your blog and adds features for comment tracking & more.
 


### PR DESCRIPTION
Includes:
* Add missing `Requires PHP` and `License` headers to the `readme.txt` file.
* Add missing `php` requirement to the `composer.json` file.
* Removing builds against PHP < 5.6.
* Removing the build against PHP 7.4 from allowed failures.
* Adding back a build against PHP `nightly` (PHP 8).
* Adjusting the Travis matrix for dropped support of WP < 5.2.
* Using the composer scripts to run various tasks.
* Dropping PHPUnit < 5.7 from the Composer `require-dev`.

Also:
* Travis hasn't supported `sudo` for quite a while now, so removing it.
* Add a `composer test` script to be in line with the other plugins.

~~This PR depends on PR #73 and can be changed from `draft` to `ready for review` once PR #73 has been merged.~~

Closes #72
Closes https://github.com/Yoast/wordpress-seo/issues/13758