### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -38,18 +38,17 @@
 		<exclude name="Yoast.Yoast.AlternativeFunctions"/>
 
 		<properties>
-			<!-- Set the minimum supported WP version for all sniff which use it in one go.
-				 The default for YoastCS is 4.9 (at this time/Oct 2019), while the Clicky plugin
-				 has a minimum WP requirement of WP 5.1.
-				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters
-			-->
-			<property name="minimum_supported_version" value="5.1"/>
-
 			<!-- Set the custom test class whitelist for all sniffs which use it in one go.
 				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
 			-->
 			<property name="custom_test_class_whitelist" type="array">
 				<element value="Clicky_UnitTestCase"/>
+			</property>
+
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\Clicky"/>
+				<element value="yoast_clicky"/>
 			</property>
 		</properties>
 	</rule>
@@ -73,34 +72,16 @@
 	<rule ref="Yoast.Files.FileName">
 		<properties>
 			<!-- Don't trigger on the main file as renaming it would deactivate the plugin. -->
-			<property name="exclude" type="array">
+			<property name="excluded_files_strict_check" type="array">
 				<element value="clicky.php"/>
 			</property>
 
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array">
+			<property name="oo_prefixes" type="array">
 				<element value="clicky"/>
 				<element value="yoast_clicky"/>
 			</property>
 		</properties>
-	</rule>
-
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<!-- Temporarily allowed until the prefixes are fixed. -->
-				<element value="clicky"/>
-
-				<!-- These are the new prefixes which all code should comply with in the future. -->
-				<element value="yoast_clicky"/>
-				<element value="Yoast\WP\Clicky"/>
-			</property>
-		</properties>
-
-		<!-- Valid usage: For testing purposes, some non-prefixed globals are being created. -->
-		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
 	</rule>
 
 
@@ -116,6 +97,11 @@
 		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Valid usage: For testing purposes, some non-prefixed globals are being created. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
+	</rule>
+
 
 	<!--
 	#############################################################################
@@ -123,6 +109,15 @@
 	Adjustments which should be removed once the associated issue has been resolved.
 	#############################################################################
 	-->
+
+	<!-- Until all prefixes are fixed, some exceptions are allowed to the PrefixAllGlobals sniff. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" extend="true">
+				<element value="clicky"/>
+			</property>
+		</properties>
+	</rule>
 
 	<rule ref="Generic.Commenting.DocComment.MissingShort">
 		<!-- Temporarily downgraded to warning to allow the build to pass.

--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -18,10 +18,10 @@ class Clicky_Admin_Page extends Clicky_Admin {
 
 		$this->options = $options_admin->get();
 
-		add_action( 'admin_print_scripts', array( $this, 'config_page_scripts' ) );
-		add_action( 'admin_print_styles', array( $this, 'config_page_styles' ) );
+		add_action( 'admin_print_scripts', [ $this, 'config_page_scripts' ] );
+		add_action( 'admin_print_styles', [ $this, 'config_page_styles' ] );
 
-		add_action( 'admin_head', array( $this, 'i18n_module' ) );
+		add_action( 'admin_head', [ $this, 'i18n_module' ] );
 	}
 
 	/**
@@ -122,7 +122,7 @@ class Clicky_Admin_Page extends Clicky_Admin {
 	 */
 	public function i18n_module() {
 		new yoast_i18n(
-			array(
+			[
 				'textdomain'     => 'clicky',
 				'project_slug'   => 'clicky-wordpress-plugin',
 				'plugin_name'    => __( 'Clicky for WordPress', 'clicky' ),
@@ -131,7 +131,7 @@ class Clicky_Admin_Page extends Clicky_Admin {
 				'glotpress_name' => __( 'Yoast Translate', 'clicky' ),
 				'glotpress_logo' => 'https://cdn.yoast.com/wp-content/uploads/i18n-images/Yoast_Translate.svg',
 				'register_url '  => 'http://translate.yoast.com/projects#utm_source=plugin&utm_medium=promo-box&utm_campaign=clicky-i18n-promo',
-			)
+			]
 		);
 	}
 }

--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -126,7 +126,7 @@ class Clicky_Admin_Page extends Clicky_Admin {
 				'textdomain'     => 'clicky',
 				'project_slug'   => 'clicky-wordpress-plugin',
 				'plugin_name'    => __( 'Clicky for WordPress', 'clicky' ),
-				'hook'           => 'clicky_admin_footer',
+				'hook'           => 'Yoast\WP\Clicky\admin_footer',
 				'glotpress_url'  => 'http://translate.yoast.com',
 				'glotpress_name' => __( 'Yoast Translate', 'clicky' ),
 				'glotpress_logo' => 'https://cdn.yoast.com/wp-content/uploads/i18n-images/Yoast_Translate.svg',

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -15,7 +15,7 @@ class Clicky_Admin {
 	 *
 	 * @var array
 	 */
-	public $options = array();
+	public $options = [];
 
 	/**
 	 * Menu slug for WordPress admin.
@@ -35,24 +35,24 @@ class Clicky_Admin {
 	public function __construct() {
 		$this->options = Clicky_Options::instance()->get();
 
-		add_filter( 'plugin_action_links', array( $this, 'add_action_link' ), 10, 2 );
+		add_filter( 'plugin_action_links', [ $this, 'add_action_link' ], 10, 2 );
 
-		add_action( 'publish_post', array( $this, 'insert_post' ) );
-		add_action( 'admin_notices', array( $this, 'admin_warnings' ) );
-		add_action( 'admin_menu', array( $this, 'admin_init' ) );
+		add_action( 'publish_post', [ $this, 'insert_post' ] );
+		add_action( 'admin_notices', [ $this, 'admin_warnings' ] );
+		add_action( 'admin_menu', [ $this, 'admin_init' ] );
 	}
 
 	/**
 	 * Initialize needed actions.
 	 */
 	public function admin_init() {
-		$public_post_types = get_post_types( array( 'public' => true ) );
+		$public_post_types = get_post_types( [ 'public' => true ] );
 
 		foreach ( $public_post_types as $post_type ) {
 			add_meta_box(
 				'clicky',
 				__( 'Clicky Goal Tracking', 'clicky' ),
-				array( $this, 'meta_box_content' ),
+				[ $this, 'meta_box_content' ],
 				$post_type,
 				'side'
 			);
@@ -73,7 +73,7 @@ class Clicky_Admin {
 			__( 'Clicky', 'clicky' ),
 			'manage_options',
 			$this->hook,
-			array( new Clicky_Admin_Page(), 'config_page' )
+			[ new Clicky_Admin_Page(), 'config_page' ]
 		);
 
 		add_dashboard_page(
@@ -81,7 +81,7 @@ class Clicky_Admin {
 			__( 'Clicky Stats', 'clicky' ),
 			'manage_options',
 			'clicky_stats',
-			array( $this, 'dashboard_page' )
+			[ $this, 'dashboard_page' ]
 		);
 	}
 
@@ -89,7 +89,7 @@ class Clicky_Admin {
 	 * Creates warnings for empty fields in the admin.
 	 */
 	public function admin_warnings() {
-		$required_options = array( 'site_id', 'site_key', 'admin_site_key' );
+		$required_options = [ 'site_id', 'site_key', 'admin_site_key' ];
 
 		foreach ( $required_options as $option ) {
 			if ( empty( $this->options[ $option ] ) ) {
@@ -148,10 +148,10 @@ class Clicky_Admin {
 	 * @param int $post_id The post ID.
 	 */
 	public function insert_post( $post_id ) {
-		$clicky_goal = array(
+		$clicky_goal = [
 			'id'    => (int) filter_input( INPUT_POST, 'clicky_goal_id' ),
 			'value' => (float) filter_input( INPUT_POST, 'clicky_goal_value' ),
-		);
+		];
 		update_post_meta( $post_id, '_clicky_goal', $clicky_goal );
 	}
 
@@ -159,10 +159,10 @@ class Clicky_Admin {
 	 * Loads (external) stats page in an iframe.
 	 */
 	public function dashboard_page() {
-		$args       = array(
+		$args       = [
 			'site_id' => $this->options['site_id'],
 			'sitekey' => $this->options['site_key'],
-		);
+		];
 		$iframe_url = add_query_arg( $args, 'https://clicky.com/stats/wp-iframe?' );
 
 		require CLICKY_PLUGIN_DIR_PATH . 'admin/views/stats-page.php';

--- a/admin/options-admin.php
+++ b/admin/options-admin.php
@@ -21,7 +21,7 @@ class Clicky_Options_Admin extends Clicky_Options {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		add_action( 'admin_init', [ $this, 'admin_init' ] );
 
 		parent::__construct();
 	}
@@ -30,7 +30,7 @@ class Clicky_Options_Admin extends Clicky_Options {
 	 * Register the needed option and its settings sections.
 	 */
 	public function admin_init() {
-		register_setting( self::$option_group, parent::$option_name, array( $this, 'sanitize_options_on_save' ) );
+		register_setting( self::$option_group, parent::$option_name, [ $this, 'sanitize_options_on_save' ] );
 
 		$this->register_basic_settings();
 		$this->register_advanced_settings();
@@ -44,24 +44,24 @@ class Clicky_Options_Admin extends Clicky_Options {
 		add_settings_section(
 			'basic-settings',
 			__( 'Basic settings', 'clicky' ),
-			array( $this, 'basic_settings_intro' ),
+			[ $this, 'basic_settings_intro' ],
 			'clicky'
 		);
 
-		$clicky_settings = array(
+		$clicky_settings = [
 			'site_id'        => __( 'Site ID', 'clicky' ),
 			'site_key'       => __( 'Site Key', 'clicky' ),
 			'admin_site_key' => __( 'Admin Site Key', 'clicky' ),
-		);
+		];
 		foreach ( $clicky_settings as $key => $label ) {
-			$args = array(
+			$args = [
 				'name'  => 'clicky[' . $key . ']',
 				'value' => $this->options[ $key ],
-			);
+			];
 			add_settings_field(
 				$key,
 				$label,
-				array( $this, 'input_text' ),
+				[ $this, 'input_text' ],
 				'clicky',
 				'basic-settings',
 				$args
@@ -71,14 +71,14 @@ class Clicky_Options_Admin extends Clicky_Options {
 		add_settings_section(
 			'clicky-like',
 			__( 'Like this plugin?', 'clicky' ),
-			array( $this, 'like_text' ),
+			[ $this, 'like_text' ],
 			'clicky'
 		);
 
 		add_settings_section(
 			'clicky-support',
 			__( 'Need support?', 'clicky' ),
-			array( $this, 'support_text' ),
+			[ $this, 'support_text' ],
 			'clicky'
 		);
 	}
@@ -89,33 +89,33 @@ class Clicky_Options_Admin extends Clicky_Options {
 	private function register_advanced_settings() {
 		add_settings_section( 'clicky-advanced', __( 'Advanced Settings', 'clicky' ), null, 'clicky-advanced' );
 
-		$advanced_settings = array(
-			'disable_stats'   => array(
+		$advanced_settings = [
+			'disable_stats'   => [
 				'label' => __( 'Disable Admin Bar stats', 'clicky' ),
 				'desc'  => __( 'If you don\'t want to display the stats in your admin menu, check this box.', 'clicky' ),
-			),
-			'ignore_admin'    => array(
+			],
+			'ignore_admin'    => [
 				'label' => __( 'Ignore Admin users', 'clicky' ),
 				'desc'  => __( 'If you are using a caching plugin, such as W3 Total Cache or WP-Supercache, please ensure that you have it configured to NOT use the cache for logged in users. Otherwise, admin users <em>will still</em> be tracked.', 'clicky' ),
-			),
-			'cookies_disable' => array(
+			],
+			'cookies_disable' => [
 				'label' => __( 'Disable cookies', 'clicky' ),
 				'desc'  => __( 'If you don\'t want Clicky to use cookies on your site, check this button. By doing so, uniqueness will instead be determined based on their IP address.', 'clicky' ),
-			),
-			'track_names'     => array(
+			],
+			'track_names'     => [
 				'label' => __( 'Track names of commenters', 'clicky' ),
-			),
-		);
+			],
+		];
 		foreach ( $advanced_settings as $key => $arr ) {
-			$args = array(
+			$args = [
 				'name'  => $key,
 				'value' => isset( $this->options[ $key ] ) ? $this->options[ $key ] : false,
 				'desc'  => isset( $arr['desc'] ) ? $arr['desc'] : '',
-			);
+			];
 			add_settings_field(
 				$key,
 				$arr['label'],
-				array( $this, 'input_checkbox' ),
+				[ $this, 'input_checkbox' ],
 				'clicky-advanced',
 				'clicky-advanced',
 				$args
@@ -130,19 +130,19 @@ class Clicky_Options_Admin extends Clicky_Options {
 		add_settings_section(
 			'clicky-outbound',
 			__( 'Outbound Links', 'clicky' ),
-			array( $this, 'outbound_explanation' ),
+			[ $this, 'outbound_explanation' ],
 			'clicky-advanced'
 		);
 
-		$args = array(
+		$args = [
 			'name'  => 'clicky[outbound_pattern]',
 			'value' => $this->options['outbound_pattern'],
 			'desc'  => __( 'For instance: <code>/out/,/go/</code>', 'clicky' ),
-		);
+		];
 		add_settings_field(
 			'outbound_pattern',
 			__( 'Outbound Link Pattern', 'clicky' ),
-			array( $this, 'input_text' ),
+			[ $this, 'input_text' ],
 			'clicky-advanced',
 			'clicky-outbound',
 			$args

--- a/admin/views/admin-page.php
+++ b/admin/views/admin-page.php
@@ -36,7 +36,7 @@
 			 *
 			 * @deprecated 1.10.0. Use the {@see 'Yoast\WP\Clicky\admin_footer'} action instead.
 			 */
-			do_action_deprecated( 'clicky_admin_footer', array(), 'Yoast Clicky 1.10.0', 'Yoast\WP\Clicky\admin_footer' );
+			do_action_deprecated( 'clicky_admin_footer', [], 'Yoast Clicky 1.10.0', 'Yoast\WP\Clicky\admin_footer' );
 
 			/**
 			 * Allow for adding content to the Yoast Clicky admin page footer.

--- a/admin/views/admin-page.php
+++ b/admin/views/admin-page.php
@@ -31,7 +31,19 @@
 		<?php
 			submit_button( __( 'Save Clicky settings', 'clicky' ) );
 
-			do_action( 'clicky_admin_footer' );
+			/**
+			 * Allow for adding content to the Yoast Clicky admin page footer.
+			 *
+			 * @deprecated 1.10.0. Use the {@see 'Yoast\WP\Clicky\admin_footer'} action instead.
+			 */
+			do_action_deprecated( 'clicky_admin_footer', array(), 'Yoast Clicky 1.10.0', 'Yoast\WP\Clicky\admin_footer' );
+
+			/**
+			 * Allow for adding content to the Yoast Clicky admin page footer.
+			 *
+			 * @since 1.10.0
+			 */
+			do_action( 'Yoast\WP\Clicky\admin_footer' );
 		?>
 	</div>
 	</form>

--- a/clicky.php
+++ b/clicky.php
@@ -44,7 +44,7 @@ class Yoast_Clicky {
 			return;
 		}
 
-		add_action( 'plugins_loaded', array( $this, 'init' ) );
+		add_action( 'plugins_loaded', [ $this, 'init' ] );
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "codeclimate/php-test-reporter": "dev-master",
-    "yoast/yoastcs": "^1.3.0",
+    "yoast/yoastcs": "^2.0.0",
     "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0"
   },
   "autoload": {
@@ -39,7 +39,7 @@
       "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
     ],
     "check-cs": [
-      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set ignore_warnings_on_exit 1"
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
     ],
     "fix-cs": [
       "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca8c94e1abf79c7e2bdac9880886ce30",
+    "content-hash": "3b72df18e9ce417d1c624c9d1782649e",
     "packages": [
         {
             "name": "composer/installers",
@@ -2080,16 +2080,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.2",
+            "version": "3.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7"
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
-                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
                 "shasum": ""
             },
             "require": {
@@ -2127,7 +2127,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-10-28T04:36:32+00:00"
+            "time": "2019-12-04T04:46:47+00:00"
         },
         {
             "name": "symfony/config",
@@ -2706,16 +2706,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.1.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f90e8692ce97b693633db7ab20bfa78d930f536a",
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a",
                 "shasum": ""
             },
             "require": {
@@ -2738,7 +2738,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -2747,30 +2747,32 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "time": "2019-11-11T12:34:03+00:00"
         },
         {
             "name": "yoast/yoastcs",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca"
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "php": ">=5.4",
-                "phpcompatibility/phpcompatibility-wp": "^2.0.0",
-                "squizlabs/php_codesniffer": "^3.4.2",
-                "wp-coding-standards/wpcs": "^2.1.1"
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+                "squizlabs/php_codesniffer": "^3.5.0",
+                "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
+                "jakub-onderka/php-console-highlighter": "^0.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
@@ -2795,7 +2797,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2019-07-31T12:06:40+00:00"
+            "time": "2019-12-17T07:40:59+00:00"
         }
     ],
     "aliases": [],

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -15,7 +15,7 @@ class Clicky_Frontend {
 	 *
 	 * @var array
 	 */
-	private $options = array();
+	private $options = [];
 
 	/**
 	 * Class constructor.
@@ -27,8 +27,8 @@ class Clicky_Frontend {
 			return;
 		}
 
-		add_action( 'wp_head', array( $this, 'script' ), 90 );
-		add_action( 'comment_post', array( $this, 'track_comment' ), 10, 2 );
+		add_action( 'wp_head', [ $this, 'script' ], 90 );
+		add_action( 'comment_post', [ $this, 'track_comment' ], 10, 2 );
 	}
 
 	/**
@@ -133,17 +133,17 @@ class Clicky_Frontend {
 			$comment = get_comment( $comment_id );
 			// Only do this for normal comments, not for pingbacks or trackbacks.
 			if ( $comment->comment_type !== 'pingback' && $comment->comment_type !== 'trackback' ) {
-				$args   = array(
+				$args   = [
 					'type'       => 'click',
 					'href'       => '/wp-comments-post.php',
 					'title'      => __( 'Posted a comment', 'clicky' ),
 					'ua'         => $comment->comment_agent,
 					'ip_address' => $comment->comment_author_IP,
-				);
-				$custom = array(
+				];
+				$custom = [
 					'username' => $comment->comment_author,
 					'email'    => $comment->comment_author_email,
-				);
+				];
 
 				$this->log_comment( $args, $custom );
 			}

--- a/frontend/visitor-graph.php
+++ b/frontend/visitor-graph.php
@@ -22,7 +22,7 @@ class Clicky_Visitor_Graph {
 	 *
 	 * @var array
 	 */
-	private $bar_values = array();
+	private $bar_values = [];
 
 	/**
 	 * Height of the generated image.
@@ -64,7 +64,7 @@ class Clicky_Visitor_Graph {
 	 *
 	 * @var array
 	 */
-	private $options = array();
+	private $options = [];
 
 	/**
 	 * The ratio between a value and the overall image height.
@@ -95,8 +95,8 @@ class Clicky_Visitor_Graph {
 			return;
 		}
 
-		add_action( 'wp_head', array( $this, 'stats_css' ) );
-		add_action( 'admin_bar_menu', array( $this, 'stats_admin_bar_menu' ), 100 );
+		add_action( 'wp_head', [ $this, 'stats_css' ] );
+		add_action( 'admin_bar_menu', [ $this, 'stats_admin_bar_menu' ], 100 );
 	}
 
 	/**
@@ -130,11 +130,11 @@ class Clicky_Visitor_Graph {
 		$url   = 'https://secure.getclicky.com/stats/?site_id=' . $this->options['site_id'];
 		$title = __( 'Visitors over 48 hours. Click for more Clicky Site Stats.', 'clicky' );
 
-		$menu = array(
+		$menu = [
 			'id'    => 'clickystats',
 			'title' => "<img width='99' height='20' src='" . $img_src . "' alt='" . esc_attr( $title ) . "' title='" . esc_attr( $title ) . "' />",
 			'href'  => $url,
-		);
+		];
 
 		$wp_admin_bar->add_menu( $menu );
 	}
@@ -167,14 +167,14 @@ class Clicky_Visitor_Graph {
 	 * @link https://codex.wordpress.org/Function_Reference/wp_remote_get
 	 */
 	private function retrieve_clicky_api_details() {
-		$args = array(
+		$args = [
 			'site_id' => $this->options['site_id'],
 			'sitekey' => $this->options['site_key'],
 			'type'    => 'visitors',
 			'hourly'  => 1,
 			'date'    => 'last-3-days',
 			'output'  => 'json',
-		);
+		];
 		$url  = 'https://api.getclicky.com/api/stats/4?' . http_build_query( $args );
 
 		$resp = wp_remote_get( $url );
@@ -212,7 +212,7 @@ class Clicky_Visitor_Graph {
 		}
 
 		$hours  = 0;
-		$values = array();
+		$values = [];
 
 		foreach ( $json[0]->dates as $date ) {
 			foreach ( $date->items as $item ) {

--- a/frontend/visitor-graph.php
+++ b/frontend/visitor-graph.php
@@ -123,7 +123,7 @@ class Clicky_Visitor_Graph {
 	 */
 	public function stats_admin_bar_menu( $wp_admin_bar ) {
 		$img_src = $this->create_graph();
-		if ( false === $img_src ) {
+		if ( $img_src === false ) {
 			return;
 		}
 
@@ -146,7 +146,7 @@ class Clicky_Visitor_Graph {
 	 */
 	private function create_graph() {
 		$result = $this->retrieve_clicky_api_details();
-		if ( false === $result ) {
+		if ( result === false ) {
 			return false;
 		}
 

--- a/includes/options.php
+++ b/includes/options.php
@@ -17,7 +17,7 @@ class Clicky_Options {
 	 *
 	 * @var array
 	 */
-	public static $option_defaults = array(
+	public static $option_defaults = [
 		'site_id'          => '',    // There is no default site ID as we don't know it...
 		'site_key'         => '',    // There is no default site key as we don't know it...
 		'admin_site_key'   => '',    // There is no default admin site key as we don't know it...
@@ -26,14 +26,14 @@ class Clicky_Options {
 		'track_names'      => false, // Tracking the names of commenters makes sense, but might be illegal in some countries, so we default to off.
 		'cookies_disable'  => false, // No need to disable cookies by default as it severely impacts the quality of tracking.
 		'disable_stats'    => false, // The stats on the frontend are often found useful, but some people might want to disable them.
-	);
+	];
 
 	/**
 	 * Holds the type of variable that each option is, so we can cast it to that.
 	 *
 	 * @var array
 	 */
-	public static $option_var_types = array(
+	public static $option_var_types = [
 		'site_id'          => 'string',
 		'site_key'         => 'string',
 		'admin_site_key'   => 'string',
@@ -42,7 +42,7 @@ class Clicky_Options {
 		'track_names'      => 'bool',
 		'cookies_disable'  => 'bool',
 		'disable_stats'    => 'bool',
-	);
+	];
 
 	/**
 	 * Name of the option we're using.
@@ -63,7 +63,7 @@ class Clicky_Options {
 	 *
 	 * @var array
 	 */
-	public $options = array();
+	public $options = [];
 
 	/**
 	 * Class constructor.

--- a/tests/admin-page-test.php
+++ b/tests/admin-page-test.php
@@ -30,9 +30,9 @@ class Clicky_Admin_Page_Test extends Clicky_UnitTestCase {
 	public function test___construct() {
 		$this->assertSame( Clicky_Options::$option_defaults, self::$class_instance->options );
 
-		$this->assertSame( 10, has_action( 'admin_print_scripts', array( self::$class_instance, 'config_page_scripts' ) ) );
-		$this->assertSame( 10, has_action( 'admin_print_styles', array( self::$class_instance, 'config_page_styles' ) ) );
-		$this->assertSame( 10, has_action( 'admin_head', array( self::$class_instance, 'i18n_module' ) ) );
+		$this->assertSame( 10, has_action( 'admin_print_scripts', [ self::$class_instance, 'config_page_scripts' ] ) );
+		$this->assertSame( 10, has_action( 'admin_print_styles', [ self::$class_instance, 'config_page_styles' ] ) );
+		$this->assertSame( 10, has_action( 'admin_head', [ self::$class_instance, 'i18n_module' ] ) );
 	}
 
 	/**

--- a/tests/admin-test.php
+++ b/tests/admin-test.php
@@ -30,11 +30,11 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 	public function test___construct() {
 		$this->assertSame( Clicky_Options::$option_defaults, self::$class_instance->options );
 
-		$this->assertSame( 10, has_filter( 'plugin_action_links', array( self::$class_instance, 'add_action_link' ) ) );
+		$this->assertSame( 10, has_filter( 'plugin_action_links', [ self::$class_instance, 'add_action_link' ] ) );
 
-		$this->assertSame( 10, has_action( 'publish_post', array( self::$class_instance, 'insert_post' ) ) );
-		$this->assertSame( 10, has_action( 'admin_notices', array( self::$class_instance, 'admin_warnings' ) ) );
-		$this->assertSame( 10, has_action( 'admin_menu', array( self::$class_instance, 'admin_init' ) ) );
+		$this->assertSame( 10, has_action( 'publish_post', [ self::$class_instance, 'insert_post' ] ) );
+		$this->assertSame( 10, has_action( 'admin_notices', [ self::$class_instance, 'admin_warnings' ] ) );
+		$this->assertSame( 10, has_action( 'admin_menu', [ self::$class_instance, 'admin_init' ] ) );
 	}
 
 	/**
@@ -83,10 +83,10 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 		global $post;
 		$post = get_post( $post_id );
 
-		$clicky_goal = array(
+		$clicky_goal = [
 			'id'    => 1,
 			'value' => 0.5,
-		);
+		];
 		update_post_meta( $post_id, '_clicky_goal', $clicky_goal );
 
 		ob_start();
@@ -101,16 +101,16 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Admin::insert_post
 	 */
 	public function test_insert_post() {
-		add_action( 'wp_insert_post', array( self::$class_instance, 'insert_post' ) );
+		add_action( 'wp_insert_post', [ self::$class_instance, 'insert_post' ] );
 
 		$post_id = $this->factory->post->create();
 
 		$goal = get_post_meta( $post_id, '_clicky_goal', true );
 
-		$expected = array(
+		$expected = [
 			'id'    => 0,
 			'value' => 0.0,
-		);
+		];
 
 		$this->assertSame( $expected, $goal );
 	}
@@ -136,7 +136,7 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 	 * @covers Clicky_Admin::add_action_link
 	 */
 	public function test_add_action_link() {
-		$output   = self::$class_instance->add_action_link( array(), CLICKY_PLUGIN_FILE );
+		$output   = self::$class_instance->add_action_link( [], CLICKY_PLUGIN_FILE );
 		$expected = '<a href="' . admin_url( 'options-general.php?page=clicky' ) . '">Settings</a>';
 
 		$this->assertSame( $expected, $output[0] );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,11 +13,11 @@ if ( function_exists( 'xdebug_disable' ) ) {
 echo 'Welcome to the Clicky Test Suite' . PHP_EOL;
 echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
 
-if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
+if ( getenv( 'WP_DEVELOP_DIR' ) !== false ) {
 	define( 'WP_DEVELOP_DIR', getenv( 'WP_DEVELOP_DIR' ) );
 }
 
-if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
+if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,9 +21,9 @@ if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
 
-$GLOBALS['wp_tests_options'] = array(
-	'active_plugins' => array( 'clicky/clicky.php' ),
-);
+$GLOBALS['wp_tests_options'] = [
+	'active_plugins' => [ 'clicky/clicky.php' ],
+];
 
 if ( defined( 'WP_DEVELOP_DIR' ) ) {
 	if ( file_exists( WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php' ) ) {

--- a/tests/options-admin-test.php
+++ b/tests/options-admin-test.php
@@ -22,10 +22,10 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 	 *
 	 * @var array
 	 */
-	public $test_args = array(
+	public $test_args = [
 		'name'  => 'testname',
 		'value' => 'testvalue',
-	);
+	];
 
 	/**
 	 * Set up the class instance to be tested.


### PR DESCRIPTION
### PHPCS: Update to YoastCS 2.0.0

This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Includes:
* A selective update of the `composer.lock` for just YoastCS and its dependencies.
* Removing the tweaks to the Composer `check-cs` script to allow for warnings (no longer needed).

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0

### CS: deprecate old-style hook and add new-style hook

This deprecates the `clicky_admin_footer` action hook in favour of the `Yoast\WP\Clicky\admin_footer` hook.

[This needs a changelog entry]

### CS: use short arrays (everywhere)

### CS: don't use Yoda conditions 

## Testing

See the test instructions in the Yoast/wpseo-woocommerce#451 PR for guidance on how to test this PR.