### PR TITLE
QA: remove unnecessary function call parameters

### DIFF
--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -83,7 +83,7 @@ class Clicky_Admin_Page extends Clicky_Admin {
 
 			$rss = '';
 			foreach ( $rss_items as $item ) {
-				$url  = preg_replace( '/#.*/', '', esc_url( $item->get_permalink(), $protocolls = null, 'display' ) );
+				$url  = preg_replace( '/#.*/', '', esc_url( $item->get_permalink() ) );
 				$rss .= '<li class="yoast">';
 				$rss .= '<a href="' . esc_url( $url . '#utm_source=wpadmin&utm_medium=sidebarwidget&utm_term=newsitem&utm_campaign=clickywpplugin' ) . '">' . $item->get_title() . '</a> ';
 				$rss .= '</li>';


### PR DESCRIPTION
1. PHP has no concept of named passed parameters, so `$protocol[l]s` is useless here.
2. `null` and `display` are the defaults for respective parameters of the `esc_url()` function, so don't need to be passed.

Ref: https://developer.wordpress.org/reference/functions/esc_url/