### PR TITLE
Bug fix: use the variable

### DIFF
--- a/frontend/visitor-graph.php
+++ b/frontend/visitor-graph.php
@@ -146,7 +146,7 @@ class Clicky_Visitor_Graph {
 	 */
 	private function create_graph() {
 		$result = $this->retrieve_clicky_api_details();
-		if ( result === false ) {
+		if ( $result === false ) {
 			return false;
 		}
 


### PR DESCRIPTION
`result` without the `$` is treated as the (undefined) constant `result` and while this may generate an "undefined constant" notice, it would not cause a parse error, however the comparison would always fail.

Fixed now.

## Testing the fix

* On `develop`, check the admin bar and take note of the visitor graph.
* Now set an invalid "Site ID" and/or "Site key" and reload the page. The graph should still show though without any usable visitor data.
* Switch to this branch, reload the page. With the invalid site information, the graph should no longer show in the admin bar.
* Reset the site information to something valid. Reload the page and the visitor graph should show correctly again.