### PR TITLE
Travis: use 7.4 not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       env: WP_VERSION=5.3 WP_MULTISITE=0
     - php: 5.6
       env: PHPLINT=1 WP_VERSION=5.2 WP_MULTISITE=1
-    - php: "7.4snapshot"
+    - php: 7.4
       env: PHPLINT=1 WP_VERSION=5.3 WP_MULTISITE=0
     - php: "nightly"
       env: PHPLINT=1
@@ -64,7 +64,7 @@ script:
 
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.4" ]]; then composer validate --no-check-all; fi
 
 after_script:
 - |


### PR DESCRIPTION
Since mid December, Travis now has a native PHP 7.4 image available.