### PR TITLE
Update travis matrix because of new WP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ matrix:
     - php: 7.3
       env: WP_VERSION=master WP_MULTISITE=1 PHPCS=1 CODE_CLIMATE=1 CODECLIMATE_REPO_TOKEN=33af926f948ae958e14a3ecdc85c24e16a42a91f2a57a9c59bfb118c71a971e2
     - php: 7.2
-      env: WP_VERSION=5.2 WP_MULTISITE=0
-    - php: 7.0
       env: WP_VERSION=5.3 WP_MULTISITE=0
+    - php: 7.0
+      env: WP_VERSION=5.4 WP_MULTISITE=0
     - php: 5.6
-      env: PHPLINT=1 WP_VERSION=5.2 WP_MULTISITE=1
+      env: PHPLINT=1 WP_VERSION=5.3 WP_MULTISITE=1
     - php: 7.4
-      env: PHPLINT=1 WP_VERSION=5.3 WP_MULTISITE=0
+      env: PHPLINT=1 WP_VERSION=5.4 WP_MULTISITE=0
     - php: "nightly"
       env: PHPLINT=1
 


### PR DESCRIPTION
* Updates the Travis matrix to reflect the newest WP release. From now on, Travis will run against WordPress 5.4 and 5.3, instead of 5.3 and 5.2.