### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for Clicky using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.editorconfig export-ignore
+/.eslintrc export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.phpcs.xml export-ignore
+/.phpcs.xml.dist export-ignore
+/.travis.yml export-ignore
+/phpcs.xml export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml export-ignore
+/phpunit.xml.dist export-ignore
+/svn-assets export-ignore
+/tests export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text


### PR DESCRIPTION
This adds a `.gitattributes` file to keep the archives GH creates of the repo clean of development related files.
In effect, this means that the stable releases as available from GH as well as through Packagist will no longer contain the unit tests or other dev-only files.

People using Composer can still get these files in their setup if they really want to, by using `--prefer-source`.

The file list is based on the files in this repo, however a critical look at this list is warranted.

Refs:
* [Reddit: I don't need your tests in my production](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production)
* [Blog: I don't need your tests in my production](https://blog.madewithlove.be/post/gitattributes/)

## Test instructions

This commit can be tested by following these steps:
* Download a zip for a tagged release and see the `tests` dir and other dev related files in the zip.
* Download the zip for this branch and see that the dev related files are no longer included in the zip.

