### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+os: linux
+dist: xenial
 language: php
-dist: trusty
+
+services:
+  - mysql
 
 cache:
   directories:
@@ -16,7 +20,7 @@ branches:
     - /^release\/\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^hotfix\/\d+\.\d+(\.\d+)?(-\S*)?$/
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - php: 7.3


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Improve CI/build checks

## Relevant technical choices:

The "trusty" environment is no longer officially supported by Travis, so let's switch to `xenial`.

This updates the Travis config to:
* Use the `xenial` distro, which at this time is the default.
* Makes the expected OS explicit (linux).
* Updates the `matrix` key to `jobs`, which is the canonical for which `matrix` is an alias.
* The `xenial` distro is quite bare, so `mysql` is not available by default. Adding this as a `service` fixes that.

## Test instructions
This PR can be tested by following these steps:

 * Check that the build passes and that the third column on the Travis page for the build says xenial.