### PR TITLE
Load admin-side scripts on settings page only

### DIFF
--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -26,9 +26,11 @@ class Clicky_Admin_Page extends Clicky_Admin {
 
 	/**
 	 * Enqueue the styles for the admin page.
+	 *
+	 * @param string $current_page The current page.
 	 */
-	public function config_page_styles( $hook ) {
-		if ( 'settings_page_clicky' !== $hook ) {
+	public function config_page_styles( $current_page ) {
+		if ( $current_page !== 'settings_page_clicky' ) {
 			return;
 		}
 		wp_enqueue_style( 'clicky-admin-css', CLICKY_PLUGIN_DIR_URL . 'css/dist/clicky_admin.css', null, CLICKY_PLUGIN_VERSION );
@@ -36,9 +38,11 @@ class Clicky_Admin_Page extends Clicky_Admin {
 
 	/**
 	 * Enqueue the scripts for the admin page.
+	 *
+	 * @param string $current_page The current page.
 	 */
-	public function config_page_scripts( $hook ) {
-		if ( 'settings_page_clicky' !== $hook ) {
+	public function config_page_scripts( $current_page ) {
+		if ( $current_page !== 'settings_page_clicky' ) {
 			return;
 		}
 		wp_enqueue_script( 'clicky-admin-js', CLICKY_PLUGIN_DIR_URL . 'js/admin.min.js', null, CLICKY_PLUGIN_VERSION, true );


### PR DESCRIPTION
## Context
Merges https://github.com/Yoast/clicky/pull/96

## Summary

This PR can be summarized in the following changelog entry:

* Loads the admin-side scripts on the Clicky settings page only. Props to [erommel](https://github.com/erommel).

## Test instructions
* 