### PR TITLE
Integration Tests: make the testsuite x-version compatible and test against PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,17 @@ jobs:
     - php: 7.3
       env: WP_VERSION=master WP_MULTISITE=1 PHPCS=1
     - php: 7.2
-      env: WP_VERSION=5.4 WP_MULTISITE=0
-    - php: 7.0
       env: WP_VERSION=5.5 WP_MULTISITE=0
+    - php: 7.0
+      env: WP_VERSION=5.6 WP_MULTISITE=0
     - php: 5.6
-      env: PHPLINT=1 WP_VERSION=5.4 WP_MULTISITE=1
+      env: PHPLINT=1 WP_VERSION=5.5 WP_MULTISITE=1
     - php: 7.4
-      env: PHPLINT=1 WP_VERSION=5.5 WP_MULTISITE=0
+      env: PHPLINT=1 WP_VERSION=5.6 WP_MULTISITE=0
+    - php: 8.0
+      env: PHPLINT=1 WP_VERSION=5.6 WP_MULTISITE=0
     - php: "nightly"
-      env: WP_VERSION=master PHPLINT=1
+      env: PHPLINT=1
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -42,7 +44,7 @@ before_install:
 
 install:
 - |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     # Update the locked-in PHPUnit version to allow for testing on PHP 8.
     travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --no-interaction --ignore-platform-reqs
   else
@@ -50,12 +52,18 @@ install:
   fi
 
 before_script:
-- bash tests/bin/before.sh $WP_VERSION
+- |
+  if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+    bash tests/bin/before.sh $WP_VERSION
+  fi
 
 script:
 - if [[ "$PHPLINT" == "1" ]]; then composer lint; fi
 - if [[ "$PHPCS" == "1" ]]; then composer check-cs; fi
-- composer test
+- |
+  if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+    composer test
+  fi
 
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
   },
   "require-dev": {
     "yoast/yoastcs": "^2.1.0",
-    "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
     "php-parallel-lint/php-parallel-lint": "^1.2",
-    "php-parallel-lint/php-console-highlighter": "^0.5"
+    "php-parallel-lint/php-console-highlighter": "^0.5",
+    "yoast/wp-test-utils": "^0.2.0"
   },
   "config": {
     "platform": {

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
       "includes/"
     ]
   },
+  "autoload-dev": {
+    "classmap": [
+      "tests/"
+    ]
+  },
   "scripts": {
     "lint": [
       "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude node_modules --exclude .git"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dadaef64c97bb31b095fff807218a24d",
+    "content-hash": "23f35b3085b1998d286892bc36055f37",
     "packages": [
         {
             "name": "composer/installers",
@@ -184,6 +184,116 @@
     ],
     "packages-dev": [
         {
+            "name": "antecedent/patchwork",
+            "version": "2.1.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b98e046dd4c0acc34a0846604f06f6111654d9ea",
+                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "http://patchwork2.org/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "time": "2019-12-22T17:52:09+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/f2295a57da59ff88621cd959dbdb4b288feefd19",
+                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.0",
+                "mockery/mockery": ">=0.9 <2",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-version/1": "1.x-dev",
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                },
+                "files": [
+                    "inc/api.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "time": "2020-10-09T06:55:33+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.0",
             "source": {
@@ -302,6 +412,118 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "60fa2f67f6e4d3634bb4a45ff3171fa52215800d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/60fa2f67f6e4d3634bb4a45ff3171fa52215800d",
+                "reference": "60fa2f67f6e4d3634bb4a45ff3171fa52215800d",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.10|^6.5|^7.5|^8.5|^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2020-08-11T18:10:21+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -803,33 +1025,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.9.0",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -862,7 +1084,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-10-03T11:07:50+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1258,23 +1480,23 @@
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -1299,7 +1521,13 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1822,16 +2050,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.13.1",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
                 "shasum": ""
             },
             "require": {
@@ -1843,7 +2071,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-main": "1.19-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -1894,16 +2126,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.35",
+            "version": "v3.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "dab657db15207879217fc81df4f875947bf68804"
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/dab657db15207879217fc81df4f875947bf68804",
-                "reference": "dab657db15207879217fc81df4f875947bf68804",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
                 "shasum": ""
             },
             "require": {
@@ -1962,24 +2194,25 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.6.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "vimeo/psalm": "<3.6.0"
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
@@ -2006,7 +2239,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-11-24T13:36:37+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2053,6 +2286,127 @@
                 "wordpress"
             ],
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "time": "2020-11-25T02:59:57+00:00"
+        },
+        {
+            "name": "yoast/wp-test-utils",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/wp-test-utils.git",
+                "reference": "7738f2449c33e4c2599bbc8b366255c161fccf89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/7738f2449c33e4c2599bbc8b366255c161fccf89",
+                "reference": "7738f2449c33e4c2599bbc8b366255c161fccf89",
+                "shasum": ""
+            },
+            "require": {
+                "brain/monkey": "^2.5.0",
+                "php": ">=5.6",
+                "yoast/phpunit-polyfills": "^0.2.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/wp-test-utils/graphs/contributors"
+                }
+            ],
+            "description": "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
+            "homepage": "https://github.com/Yoast/wp-test-utils/",
+            "keywords": [
+                "brainmonkey",
+                "integration-testing",
+                "phpunit",
+                "unit-testing",
+                "wordpress"
+            ],
+            "time": "2020-12-09T13:26:23+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
+		forceCoversAnnotation="true"
 		processIsolation="false"
 		stopOnError="false"
 		stopOnFailure="false"
@@ -23,7 +24,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
 			<file>./clicky.php</file>
 			<directory>./admin</directory>
 			<directory>./frontend</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -61,6 +61,3 @@ tests_add_filter( 'plugins_url', '_plugins_url', 10, 3 );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
-
-// Include unit test base class.
-require_once __DIR__ . '/framework/unittestcase.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,8 @@
  * @package Yoast/Clicky/Tests
  */
 
+use Yoast\WPTestUtils\WPIntegration;
+
 // Disable xdebug backtrace.
 if ( function_exists( 'xdebug_disable' ) ) {
 	xdebug_disable();
@@ -13,15 +15,10 @@ if ( function_exists( 'xdebug_disable' ) ) {
 echo 'Welcome to the Clicky Test Suite' . PHP_EOL;
 echo 'Version: 2.0' . PHP_EOL . PHP_EOL;
 
-// Determine the WP_TEST_DIR.
-if ( getenv( 'WP_TESTS_DIR' ) !== false ) {
-	$_tests_dir = getenv( 'WP_TESTS_DIR' );
-}
+require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
-// Fall back on the WP_DEVELOP_DIR environment variable.
-if ( empty( $_tests_dir ) && getenv( 'WP_DEVELOP_DIR' ) !== false ) {
-	$_tests_dir = rtrim( getenv( 'WP_DEVELOP_DIR' ), '/' ) . '/tests/phpunit';
-}
+// Determine the WP_TEST_DIR.
+$_tests_dir = WPIntegration\get_path_to_wp_test_dir();
 
 // Give access to tests_add_filter() function.
 require_once rtrim( $_tests_dir, '/' ) . '/includes/functions.php';
@@ -59,5 +56,7 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Overwrite the plugin URL to not include the full path.
 tests_add_filter( 'plugins_url', '_plugins_url', 10, 3 );
 
-// Start up the WP testing environment.
-require $_tests_dir . '/includes/bootstrap.php';
+/*
+ * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.
+ */
+WPIntegration\bootstrap_it();

--- a/tests/framework/unittestcase.php
+++ b/tests/framework/unittestcase.php
@@ -5,27 +5,9 @@
  * @package Yoast/Clicky/Tests
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
- * TestCase base class for convenience methods.
+ * TestCase base class.
  */
-class Clicky_UnitTestCase extends WP_UnitTestCase {
-
-	/**
-	 * Fake a request to the WP front page.
-	 */
-	protected function go_to_home() {
-		$this->go_to( home_url( '/' ) );
-	}
-
-	/**
-	 * Tests whether output contains an expected string.
-	 *
-	 * @param string $string   Expected output.
-	 * @param null   $function Unused.
-	 */
-	protected function expectOutput( $string, $function = null ) {
-		$output = ob_get_contents();
-		ob_clean();
-		$this->assertSame( $string, $output );
-	}
-}
+abstract class Clicky_UnitTestCase extends TestCase {}

--- a/tests/options-admin-test.php
+++ b/tests/options-admin-test.php
@@ -83,7 +83,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertGreaterThan( 0, strlen( $output ) );
-		$this->assertContains( '//clicky.com/145844', $output );
+		$this->assertStringContainsString( '//clicky.com/145844', $output );
 	}
 
 	/**
@@ -110,7 +110,7 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertGreaterThan( 0, strlen( $output ) );
-		$this->assertContains( 'clicky.com/forums', $output );
+		$this->assertStringContainsString( 'clicky.com/forums', $output );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* (Preparation for) compatibility with PHP 8

## Summary

This PR can be summarized in the following changelog entry:

* (Preparation for) compatibility with PHP 8

## Relevant technical choices:

:bulb: This PR will be easiest to review by going through the individual commits one by one.

### Composer: add `autoload-dev`

... to include the test files in the Composer classmap when a "normal" `composer install` is run.

That way, no explicit `include|require[_once]` statements are needed for the test suite.

### Composer: require Yoast/wp-test-utils

* Adds a dev dependency to the `yoast/wp-test-utils` package, which will also make the PHPUnit Polyfills available.
* As that package already requires and manages the installable versions for PHPUnit, remove this as an explicit requirement from `require-dev` in favour of letting the WP Test Utils package manage the versions.

The install is done based on PHP 5.6 (`config.platform.php` is set in the `composer.json` file) and includes updating the dependencies from PHPUnit itself within the constraints of maintaining compatibility with PHP 5.6.

This new package adds the following features:
* Polyfills for various PHPUnit cross-version changes.
* Basic test cases for use by the plugins.

Refs:
* https://github.com/Yoast/wp-test-utils
* https://github.com/Yoast/PHPUnit-Polyfills/

### Clicky_UnitTestCase: switch parent class

This switches the parent class of the `Clicky_UnitTestCase` to the WP Test Utils `Yoast\WPTestUtils\WPIntegration\TestCase`.

Includes:
* Removing the `expectOutput()` method.
    This method is not used in this test suite and shouldn't be needed anyway as PHPUnit has build-in `expectOutputString()` and `expectOutputRegex()` methods which should be used instead.
    Additionally, WP Test Utils contains an `expectOutputContains()` method to complement the PHPUnit native methods.
* Removing other methods which were unused in this test suite.
    This applies to all the other methods.

This leaves the `Clicky_UnitTestCase` as an opaque class.
I've elected to let it remain though for the following reasons:
* Allows for adding future _plugin-specific_ test helper methods.
* Convenience as all test cases for this plugin `extend` from this one and any future changes in inheritance would only need to be applied to this class to apply them effectively to all test classes for this plugin.

Lastly, this commit makes sure that the generic test case is declared as `abstract` as it doesn't contain any tests itself.

### Tests: use the bootstrap utilities from WP Test Utils

For integration tests, WP Test Utils contains a `bootstrap-functions.php` file with utility functions for a number of common patterns used in bootstrap files for WP integration tests.

As the order in which things get loaded is _**extremely**_ important for the integration tests, whenever possible, the `WPIntegration\bootstrap_it()` method should be used.

This method will:
- Verify that the Composer `autoload.php` file exists.
- Load WordPress.
    The location for WP can be configured by setting either the `WP_TESTS_DIR` or the `WP_DEVELOP_DIR` environment variable on an OS level or via a custom `phpunit.xml` file.
    If neither of these two environment variables is found, it is presumed that the plugin is installed in `src/wp-content/plugins/plugin-name`.
    _This is compatible with the old bootstrap setup and developers will not need to make any changes to their environment for this to work._
- While loading WordPress, the plugin will be loaded, including the Composer autoload file.
- And lastly, a custom autoloader will be added to handle the PHPUnit 7.x MockObject classes not being compatible with PHP 8.0.
    This custom autoloader will load the copies of the PHPUnit 9.x MockObject classes which are part of the WP native test suite as of WP 5.6 when PHP 8.x is detected, and will let the composer autoloader load the PHPUnit native versions when not on PHP 8.x.

If anything goes wrong during these steps, the WP Test Utils method will provide human readable error messages, similar to before.


### Tests: modernize used assertions

The PHPUnit Polyfills allows for using PHPUnit 9.x assertions, even when the tests are being run on older PHPUnit versions.

This updates select assertions to the modern PHPUnit syntax, most notably, it switches out the following assertions:
* `assertContains()` with string haystacks for  `assertStringContainsString()`.

Note: the method calls switched over are based on tests run on PHPUnit 8/9 (don't ask how I did that) and only those assertions which _need_ to be switched over to prevent issues in the future, have been.

### PHPUnit config: improve code coverage configuration

* Add `addUncoveredFilesFromWhitelist` and `processUncoveredFilesFromWhitelist` directives with sensible values.
* Add the `forceCoversAnnotation` attribute to only record code coverage for the method under test as annotated via a `@covers` annotation.

Based on this configuration, the strict code coverage for this testsuite is currently 15.94%.

### Travis: run the tests against PHP 8.0

Context:
* Since this Friday, Travis now has a PHP 8.0 image available.
* Any PHP 8 related fixes have gone into WP 5.6. Running the integration tests against earlier WP versions is futile.
* The tests for Clicky were previously activated to run on PHP `nightly` which was possible because _mocking_ is not used in this test suite.

This commit partially reverts the previous commit which activated the tests on `nightly`.
- The tests will now be run on PHP `8.0` with `WP_VERSION` set to `5.6`.
- For now, the code will only be linted on PHP `nightly`.

Includes updating the matrix for the release of WP 5.6.



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run and 3) the tests pass.

To test locally, it will be simplest to:
1. Run `composer install`.
2. Run `composer test` on any PHP version below 8.0 and see the tests pass.
    This confirms that the changes to the test bootstrap and the `TestCase` work correctly.
3. Switch to PHP 8.
4. Run `composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs`
5. Run `composer test` to see the tests running and passing on PHP 8 in combination with PHPUnit 7.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 7.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage base on these tests, as noted above, is only ~15.9%.