### PR TITLE
CS/QA: rename a function parameter

### DIFF
--- a/admin/options-admin.php
+++ b/admin/options-admin.php
@@ -159,12 +159,12 @@ class Clicky_Options_Admin extends Clicky_Options {
 	/**
 	 * Sanitizes and trims a string.
 	 *
-	 * @param string $string String to sanitize.
+	 * @param string $text_string String to sanitize.
 	 *
 	 * @return string
 	 */
-	private function sanitize_string( $string ) {
-		return (string) trim( sanitize_text_field( $string ) );
+	private function sanitize_string( $text_string ) {
+		return (string) trim( sanitize_text_field( $text_string ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Improved compatibility for PHP 8.0.

## Summary

This PR can be summarized in the following changelog entry:

* Improved compatibility for PHP 8.0.

## Relevant technical choices:

### CS/QA: rename a function parameter

... to prevent using a reserved keyword as a parameter name.

While this isn't forbidden, in PHP 8.0+ with named parameters this can lead to very confusing code, so better to use another name.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This PR does not contain functional changes. If the build passes, we're good.