### PR TITLE
P2-1217 Change tracking code, add CSP support

### DIFF
--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -94,7 +94,7 @@ class Clicky_Frontend {
 
 		// Bail early if current user is admin and ignore admin is true.
 		if ( $this->options['ignore_admin'] && current_user_can( 'manage_options' ) ) {
-			echo "\n<!-- " . esc_html__( "Clicky tracking not shown because you are an administrator and you have configured Clicky to ignore administrators.", 'clicky' ) . " -->\n";
+			echo "\n<!-- " . esc_html__( 'Clicky tracking not shown because you are an administrator and you have configured Clicky to ignore administrators.', 'clicky' ) . " -->\n";
 
 			return;
 		}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -94,7 +94,7 @@ class Clicky_Frontend {
 
 		// Bail early if current user is admin and ignore admin is true.
 		if ( $this->options['ignore_admin'] && current_user_can( 'manage_options' ) ) {
-			echo "\n<!-- " . esc_html__( "Clicky tracking not shown because you're an administrator and you've configured Clicky to ignore administrators.", 'clicky' ) . " -->\n";
+			echo "\n<!-- " . esc_html__( "Clicky tracking not shown because you are an administrator and you have configured Clicky to ignore administrators.", 'clicky' ) . " -->\n";
 
 			return;
 		}

--- a/frontend/frontend.php
+++ b/frontend/frontend.php
@@ -74,11 +74,11 @@ class Clicky_Frontend {
 
 		if ( $this->options['track_names'] ) {
 			$this->names_nonce = wp_create_nonce( 'clicky_names_script_nonce' );
-			header( "Content-Security-Policy: script-src 'nonce-" . $this->names_nonce . "'" );
+			header( "Content-Security-Policy: script-src 'nonce-" . $this->names_nonce . "'", false );
 		}
 		if ( ! empty( $this->inline_script ) ) {
 			$this->extra_nonce = wp_create_nonce( 'clicky_script_nonce' );
-			header( "Content-Security-Policy: script-src 'nonce-" . $this->extra_nonce . "'" );
+			header( "Content-Security-Policy: script-src 'nonce-" . $this->extra_nonce . "'", false );
 		}
 	}
 

--- a/frontend/views/comment-author-script.php
+++ b/frontend/views/comment-author-script.php
@@ -5,8 +5,14 @@
  * @package Yoast/Clicky/View
  */
 
+/**
+ * Global for CSP nonce.
+ *
+ * @var string $names_nonce
+ */
+
 ?>
-<script type='text/javascript'>
+<script type='text/javascript' nonce='<?php echo esc_attr( $names_nonce ); ?>'>
 	function clicky_gc(name) {
 		var ca = document.cookie.split(';');
 		for (var i in ca) {

--- a/frontend/views/script.php
+++ b/frontend/views/script.php
@@ -24,4 +24,4 @@ if ( ! empty( $clicky_extra ) ) {
 }
 
 // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-echo '<script async src="//static.getclicky.com/' . esc_attr( $this->options['site_id'] ) . 'js"></script>' . "\n";
+echo '<script async src="//static.getclicky.com/' . esc_attr( $this->options['site_id'] ) . '.js"></script>' . "\n";

--- a/frontend/views/script.php
+++ b/frontend/views/script.php
@@ -5,19 +5,23 @@
  * @package Yoast/Clicky/View
  */
 
-?>
-<script>
-	<?php
-	if ( ! empty( $clicky_extra ) ) {
+/**
+ * Global for CSP nonce.
+ *
+ * @var string $clicky_extra_nonce
+ */
+
+if ( ! empty( $clicky_extra ) ) {
+	?>
+	<script nonce="<?php echo esc_attr( $clicky_extra_nonce ); ?>">
+		<?php
 		echo 'var clicky_custom = clicky_custom || {}; ';
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $clicky_extra;
-	}
-	?>
+		?>
+	</script>
+	<?php
+}
 
-	var clicky_site_ids = clicky_site_ids || [];
-	clicky_site_ids.push(<?php echo wp_json_encode( $this->options['site_id'] ); ?>);
-</script>
-<?php
 // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-echo '<script async src="//static.getclicky.com/js"></script>';
+echo '<script async src="//static.getclicky.com/' . esc_attr( $this->options['site_id'] ) . 'js"></script>' . "\n";

--- a/includes/options.php
+++ b/includes/options.php
@@ -93,6 +93,10 @@ class Clicky_Options {
 	 */
 	private function sanitize_options() {
 		foreach ( $this->options as $key => $value ) {
+			if ( ! isset( self::$option_var_types[ $key ] ) ) {
+				unset( $this->options[ $key ] );
+				continue;
+			}
 			switch ( self::$option_var_types[ $key ] ) {
 				case 'string':
 					$this->options[ $key ] = (string) $value;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Got an email from Sean at Clicky asking to change the tracking code and add support for CSP. This pull does that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the Clicky tracking code to a new format.
* Adds CSP support by adding CSP nonces to the Clicky scripts we output. Doesn't actually send CSP headers.

## Relevant technical choices:

* Had to move some of the code around to determine whether we need to send CSP headers. Relevant mozilla docs for the `nonce` attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

(Test instructions edited by @johannadevos)

#### Setting up a test environment
* Make sure you have a live website to test on (maybe yoast.com itself, alternatively we have demo.yoast.com for which @Djennez can set up an account).
* Upload the Clicky RC in the back-end of your test website, and activate the plugin.
* Create a (free) account on https://clicky.com.
* Log in, and register the URL of your website. 
* Under Preferences > Info you can find the `Site ID`, `Site key` and `Admin site key`.
* Enter these values under Settings > Clicky > Basic settings, in the back-end of your test website.

#### Testing the changes
* Visit a post on the front-end and open the page source.
* Search for 'clicky' to find the Clicky output.
* See that the site id is now part of the tracking script (`//static.getclicky.com/123.js` for site id 123 instead of `//static.getclicky.com/js`).
* In the advanced Clicky settings in the back-end, check "Track names of commenters" and save. 
* Open the network tab in the inspector.
* Refresh the page source and see that the Clicky output now has a new `<script>` tag, which includes a nonce (e.g. `nonce = '554120b170'` - the number would be different for you).
* In the advanced Clicky settings in the back-end, check "Disable cookies" and save.
* After refresh, see that another `<script>` tag with a nonce has appeared in the page source.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
