### PR TITLE
Travis: update WP versions against which tests are run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ jobs:
     - php: 7.3
       env: WP_VERSION=master WP_MULTISITE=1 PHPCS=1
     - php: 7.2
-      env: WP_VERSION=5.5 WP_MULTISITE=0
-    - php: 7.0
       env: WP_VERSION=5.6 WP_MULTISITE=0
+    - php: 7.0
+      env: WP_VERSION=5.8 WP_MULTISITE=0
     - php: 5.6
-      env: PHPLINT=1 WP_VERSION=5.5 WP_MULTISITE=1
+      env: PHPLINT=1 WP_VERSION=5.6 WP_MULTISITE=1
     - php: 7.4
-      env: PHPLINT=1 WP_VERSION=5.6 WP_MULTISITE=0
+      env: PHPLINT=1 WP_VERSION=5.7 WP_MULTISITE=0
     - php: 8.0
-      env: PHPLINT=1 WP_VERSION=5.6 WP_MULTISITE=0
+      env: PHPLINT=1 WP_VERSION=5.8 WP_MULTISITE=0
     - php: "nightly"
       env: PHPLINT=1
 


### PR DESCRIPTION
## Context

* Update CI

## Summary

This PR can be summarized in the following changelog entry:

* Updates CI

## Relevant technical choices:

According to the `readme.txt`, Clicky current supports:
```
Requires at least: 5.6
Tested up to: 5.8
```

So, let's stop running the tests against WP 5.5 and actually run them against WP 5.6-5.8.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_