### PR TITLE
Update (fix) test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ phpunit.xml
 .phpcs.xml
 phpcs.xml
 .cache/phpcs.cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,6 @@ jobs:
       env: PHPLINT=1 WP_VERSION=5.7 WP_MULTISITE=0
     - php: 8.0
       env: PHPLINT=1 WP_VERSION=5.8 WP_MULTISITE=0
-    - php: "nightly"
-      env: PHPLINT=1
-
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "nightly"
 
 before_install:
 - export WP_DEVELOP_DIR=/tmp/wordpress/

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,12 @@ before_install:
 - export WP_DEVELOP_DIR=/tmp/wordpress/
 
 install:
+  # Update the locked-in PHPUnit version to allow for testing on PHP 8/testing with WP 5.9+.
 - |
-  if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
-    # Update the locked-in PHPUnit version to allow for testing on PHP 8.
+  if [[ "$WP_VERSION" != "latest" ]] && [[ "$WP_VERSION" == "5.9" || "${WP_VERSION:0:1}" == "6" || "$WP_VERSION" == "master" ]]; then
+    composer config --unset platform.php
+    travis_retry composer update yoast/wp-test-utils --with-all-dependencies --no-interaction
+  elif [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --no-interaction --ignore-platform-reqs
   else
     travis_retry composer install --no-interaction
@@ -68,4 +71,3 @@ script:
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
 - if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.4" ]]; then composer validate --no-check-all; fi
-

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "yoast/yoastcs": "^2.2.0",
-    "yoast/wp-test-utils": "^0.2.0"
+    "yoast/wp-test-utils": "^1.0.0"
   },
   "config": {
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f33beb0dbc09e638544dd618dfabd13c",
+    "content-hash": "d931af3adad7b35543f42667846bcb9b",
     "packages": [
         {
             "name": "composer/installers",
@@ -193,16 +193,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.12",
+            "version": "2.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea"
+                "reference": "0430ceaac7f447f1778c199ec19d7e4362a6f961"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b98e046dd4c0acc34a0846604f06f6111654d9ea",
-                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/0430ceaac7f447f1778c199ec19d7e4362a6f961",
+                "reference": "0430ceaac7f447f1778c199ec19d7e4362a6f961",
                 "shasum": ""
             },
             "require": {
@@ -235,9 +235,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.12"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.15"
             },
-            "time": "2019-12-22T17:52:09+00:00"
+            "time": "2021-08-22T08:00:13+00:00"
         },
         {
             "name": "brain/monkey",
@@ -490,16 +490,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "31467aeb3ca3188158613322d66df81cedd86626"
+                "reference": "472fa8ca4e55483d55ee1e73c963718c4393791d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/31467aeb3ca3188158613322d66df81cedd86626",
-                "reference": "31467aeb3ca3188158613322d66df81cedd86626",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/472fa8ca4e55483d55ee1e73c963718c4393791d",
+                "reference": "472fa8ca4e55483d55ee1e73c963718c4393791d",
                 "shasum": ""
             },
             "require": {
@@ -553,9 +553,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.3.4"
+                "source": "https://github.com/mockery/mockery/tree/1.3.5"
             },
-            "time": "2021-02-24T09:51:00+00:00"
+            "time": "2021-09-13T15:33:03+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2456,16 +2456,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "f014fb21c2b0038fd329515d59025af42fb98715"
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/f014fb21c2b0038fd329515d59025af42fb98715",
-                "reference": "f014fb21c2b0038fd329515d59025af42fb98715",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
                 "shasum": ""
             },
             "require": {
@@ -2473,9 +2473,7 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "yoast/yoastcs": "^2.1.0"
+                "yoast/yoastcs": "^2.2.0"
             },
             "type": "library",
             "extra": {
@@ -2515,31 +2513,29 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-08-09T16:28:08+00:00"
+            "time": "2021-10-03T08:40:26+00:00"
         },
         {
             "name": "yoast/wp-test-utils",
-            "version": "0.2.2",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "896f7640d86162ff7a0dc6ce59f8837f284521c5"
+                "reference": "21df3a08974ee62f489f64e34be7f26a32ec872c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/896f7640d86162ff7a0dc6ce59f8837f284521c5",
-                "reference": "896f7640d86162ff7a0dc6ce59f8837f284521c5",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/21df3a08974ee62f489f64e34be7f26a32ec872c",
+                "reference": "21df3a08974ee62f489f64e34be7f26a32ec872c",
                 "shasum": ""
             },
             "require": {
                 "brain/monkey": "^2.6.0",
                 "php": ">=5.6",
-                "yoast/phpunit-polyfills": "^1.0.0"
+                "yoast/phpunit-polyfills": "^1.0.1"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "yoast/yoastcs": "^2.1.0"
+                "yoast/yoastcs": "^2.2.0"
             },
             "type": "library",
             "extra": {
@@ -2551,6 +2547,10 @@
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "exclude-from-classmap": [
+                    "/src/WPIntegration/TestCase.php",
+                    "/src/WPIntegration/TestCaseNoPolyfills.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2581,7 +2581,7 @@
                 "issues": "https://github.com/Yoast/wp-test-utils/issues",
                 "source": "https://github.com/Yoast/wp-test-utils"
             },
-            "time": "2021-06-21T03:45:02+00:00"
+            "time": "2021-09-27T05:50:36+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/tests/admin-page-test.php
+++ b/tests/admin-page-test.php
@@ -20,7 +20,8 @@ class Clicky_Admin_Page_Test extends Clicky_UnitTestCase {
 	/**
 	 * Set up the class instance to be tested.
 	 */
-	public static function setUpBeforeClass() {
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
 		self::$class_instance = new Clicky_Admin_Page();
 	}
 

--- a/tests/admin-test.php
+++ b/tests/admin-test.php
@@ -20,7 +20,8 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 	/**
 	 * Set up the class instance to be tested.
 	 */
-	public static function setUpBeforeClass() {
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
 		self::$class_instance = new Clicky_Admin();
 	}
 

--- a/tests/options-admin-test.php
+++ b/tests/options-admin-test.php
@@ -30,7 +30,8 @@ class Clicky_Options_Admin_Test extends Clicky_UnitTestCase {
 	/**
 	 * Set up the class instance to be tested.
 	 */
-	public static function setUpBeforeClass() {
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
 		self::$class_instance = new Clicky_Options_Admin();
 	}
 

--- a/tests/options-test.php
+++ b/tests/options-test.php
@@ -20,7 +20,8 @@ class Clicky_Options_Test extends Clicky_UnitTestCase {
 	/**
 	 * Set up the class instance to be tested.
 	 */
-	public static function setUpBeforeClass() {
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
 		self::$class_instance = new Clicky_Options();
 	}
 


### PR DESCRIPTION
## Context

* Update test setup

## Summary

This PR can be summarized in the following changelog entry:

* Updates test setup

## Relevant technical choices:

See the [Make Core dev-note about the test changes](https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/) for the context of these changes.

### Composer: update to WP Test Utils 1.0.0

WP Test Utils 1.0.0 provides cross-version compatibility with the test setup from WP < 5.9 and WP 5.9+.

Includes updating the dependencies of WP Test Utils.

Refs:
* https://github.com/Yoast/wp-test-utils/releases/
* https://github.com/Yoast/PHPUnit-Polyfills/releases/
* https://github.com/mockery/mockery/releases/tag/1.3.5
* https://github.com/antecedent/patchwork/releases

### Integration tests: switch to snake_case fixtures

Switches over `setUpBeforeClass()` to `set_up_before_class()`.

Includes fixing:
* Missing calls to the `parent::set_up_before_class()`.

### Travis: update for using correct PHPUnit version with WP 5.9+

As of WP 5.9, the integration tests can run on PHPUnit 5.7 - 9.x and should use the most appropriate PHPUnit version for the PHP version on which the tests are being run.

For WP < 5.9, the range of supported PHPUnit versions is still PHPUnit 5.7 - 7.x.

With that in mind and with there being a) a `config - platform - php` setting and b) a committed `composer.lock` file, some version juggling needs to be done.

For WP < 5.9, the logic previously used remains in place.
For WP 5.9, new logic is introduced.

Includes:
* Adding the PHPUnit cache file which is generated when using PHPUnit 8/9 to `.gitignore`.

### Travis: remove nightly

At this time, the current PHP 8.0 version is `8.0.11`. The Travis PHP `8.0` image yields PHP `8.0.9`, which is good enough for PHP 8.0.

`nightly` however is PHP `8.0.3` and hasn't been updated since Feb 2021, so running tests against that image is completely useless at this time.

Notes:
    * Tested `nightly` against all relevant `dist`s - `xenial`, `bionic` and `focal` and none have a more current image.
    * The [PHP Build project](https://github.com/php-build/php-build/tree/master/share/php-build/definitions), which Travis pulls its images from, _does_ have a PHP `8.1snapshot` image available.
        I've tested to see if that image is available on Travis, but unfortunately, no luck there either.



## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify that the builds run correctly and use the correct PHPUnit version when run against WP 5.9/`master`.