### PR TITLE
GH Actions: various tweaks / fix build on PHP 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,18 +119,22 @@ jobs:
           composer-options: "yoast/wp-test-utils --with-dependencies"
 
       ### Install type 2.
-      - name: "Install type 2: conditionally require a higher PHPUnit version"
-        if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
-        run: composer require --dev phpunit/phpunit:"^7.5" --no-update --ignore-platform-req=php
-
+      # Note: the steps for this type have (temporarily) been changed to get round
+      # a Composer bug: https://github.com/composer/composer/issues/10394
+      # Once that bug has been fixed, it is recommended to revert these steps to the
+      # more optimized version which was previously in place.
       - name: "Install type 2: install Composer dependencies - WP < 5.9 with PHP >= 8.0"
         if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
+        # This is just a plain install to still be able to use the cache for the most part.
         uses: ramsey/composer-install@v1
-        with:
-          # Force a `composer update` run.
-          dependency-versions: "highest"
-          # But make it selective.
-          composer-options: "yoast/wp-test-utils phpunit/phpunit --with-dependencies --ignore-platform-req=php"
+
+      - name: "Install type 2: remove wp-test-utils (temporary - Composer bug #10394)"
+        if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
+        run: composer remove --dev yoast/wp-test-utils --no-interaction
+
+      - name: "Install type 2: reinstall wp-test-utils with specific PHPUnit version (temporary - Composer bug #10394)"
+        if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
+        run: composer require --dev yoast/wp-test-utils:"^1.0.0" phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction
 
       ### Install type 3.
       - name: "Install type 3: install Composer dependencies - WP < 5.9 with PHP < 8.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,17 +99,17 @@ jobs:
       - name: Debug info - show type determined
         run: echo ${{ steps.composer_toggle.outputs.TYPE }}
 
-      - name: Conditionally remove the PHP platform requirement
+      # Install dependencies and handle caching in one go.
+      # Includes updating the test dependencies to the most appropriate version
+      # for the PHP/WP version combination on which the tests will be run.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+
+      ### Install type 1.
+      - name: "Install type 1: remove the PHP platform requirement"
         if: ${{ steps.composer_toggle.outputs.TYPE == '1' }}
         run: composer config --unset platform.php
 
-      - name: Conditionally require a higher PHPUnit version
-        if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
-        run: composer require --dev phpunit/phpunit:"^7.5" --no-update --ignore-platform-req=php
-
-      # Install dependencies and handle caching in one go.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies - WP 5.9 or higher
+      - name: "Install type 1: install Composer dependencies - WP 5.9 or higher"
         if: ${{ steps.composer_toggle.outputs.TYPE == '1' }}
         uses: ramsey/composer-install@v1
         with:
@@ -118,7 +118,12 @@ jobs:
           # But make it selective.
           composer-options: "yoast/wp-test-utils --with-dependencies"
 
-      - name: Install Composer dependencies - WP < 5.9 with PHP >= 8
+      ### Install type 2.
+      - name: "Install type 2: conditionally require a higher PHPUnit version"
+        if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
+        run: composer require --dev phpunit/phpunit:"^7.5" --no-update --ignore-platform-req=php
+
+      - name: "Install type 2: install Composer dependencies - WP < 5.9 with PHP >= 8.0"
         if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
         uses: ramsey/composer-install@v1
         with:
@@ -127,7 +132,8 @@ jobs:
           # But make it selective.
           composer-options: "yoast/wp-test-utils phpunit/phpunit --with-dependencies --ignore-platform-req=php"
 
-      - name: Install Composer dependencies - WP < 5.9 with PHP < 8
+      ### Install type 3.
+      - name: "Install type 3: install Composer dependencies - WP < 5.9 with PHP < 8.0"
         if: ${{ steps.composer_toggle.outputs.TYPE == '3' }}
         uses: ramsey/composer-install@v1
 


### PR DESCRIPTION
## Context

* Improve/fix CI

## Summary


This PR can be summarized in the following changelog entry:

* Improve/fix CI

## Relevant technical choices:

### GH Actions: improve step order and names

.. for the steps in the integration test workflow.

### GH Actions: fix integration test build on PHP >= 8.0

Composer 2.2 contains a a bug/over-optimization, which causes the install with changed, but compatible requirements to error out on "conflicting" requirements.

This commit puts a work-around for this in place, which still tries to use the caching for the Composer install as much as possible.

It is recommended to revert this commit if/when the Composer bug has been fixed and a new version has been released.

Ref:
* Bug report: composer/composer#10394
* Probable cause: composer/composer#9620
* Similar fix in YoastSEO: Yoast/wordpress-seo@b399942

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ if the build passes, we're good.