### PR TITLE
GH Actions: PHP 8.1 has been released / failures no longer allowed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
     name: "Lint: PHP ${{ matrix.php_version }}"
 
     # Allow builds to fail on as-of-yet unreleased PHP versions.
-    continue-on-error: ${{ matrix.php_version == '8.1' || matrix.php_version == '8.2' }}
+    continue-on-error: ${{ matrix.php_version == '8.2' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     name: "Integration Test: PHP ${{ matrix.php_version }} | WP ${{ matrix.wp_version }} | multisite: ${{ matrix.multisite }}"
 
     # Allow builds to fail on as-of-yet unreleased PHP versions.
-    continue-on-error: ${{ matrix.php_version == '8.1' || matrix.wp_version == 'trunk' }}
+    continue-on-error: ${{ matrix.wp_version == 'trunk' }}
 
     services:
       mysql:


### PR DESCRIPTION
## Context

* Safeguards PHP 8.1 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Safeguards PHP 8.1 compatibility

## Relevant technical choices:

PHP 8.1 has been released, so builds against PHP 8.1 should no longer be allowed to fail.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.