### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -39,7 +39,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       # Check the codestyle of the files.
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: "Install type 1: install Composer dependencies - WP 5.9 or higher"
         if: ${{ steps.composer_toggle.outputs.TYPE == '1' }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           # Force a `composer update` run.
           dependency-versions: "highest"
@@ -126,7 +126,7 @@ jobs:
       - name: "Install type 2: install Composer dependencies - WP < 5.9 with PHP >= 8.0"
         if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
         # This is just a plain install to still be able to use the cache for the most part.
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: "Install type 2: remove wp-test-utils (temporary - Composer bug #10394)"
         if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
@@ -139,7 +139,7 @@ jobs:
       ### Install type 3.
       - name: "Install type 3: install Composer dependencies - WP < 5.9 with PHP < 8.0"
         if: ${{ steps.composer_toggle.outputs.TYPE == '3' }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Install WP
         run: tests/bin/install-wp-tests.sh wordpress_tests root '' 127.0.0.1:3306 ${{ matrix.wp_version }}


### PR DESCRIPTION
## Context

* CI tooling

## Summary

This PR can be summarized in the following changelog entry:

* Updates CI tooling

## Relevant technical choices:

The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2
* https://github.com/ramsey/composer-install/releases/tag/2.0.3
* https://github.com/ramsey/composer-install/releases/tag/2.0.4
* https://github.com/ramsey/composer-install/releases/tag/2.0.5

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.