### PR TITLE
GH Actions: remove "fix integration test build on PHP >= 8.0"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,22 +119,18 @@ jobs:
           composer-options: "yoast/wp-test-utils --with-dependencies"
 
       ### Install type 2.
-      # Note: the steps for this type have (temporarily) been changed to get round
-      # a Composer bug: https://github.com/composer/composer/issues/10394
-      # Once that bug has been fixed, it is recommended to revert these steps to the
-      # more optimized version which was previously in place.
+      - name: "Install type 2: conditionally require a higher PHPUnit version"
+        if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
+        run: composer require --dev phpunit/phpunit:"^7.5" --no-update --ignore-platform-req=php
+
       - name: "Install type 2: install Composer dependencies - WP < 5.9 with PHP >= 8.0"
         if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
-        # This is just a plain install to still be able to use the cache for the most part.
         uses: ramsey/composer-install@v2
-
-      - name: "Install type 2: remove wp-test-utils (temporary - Composer bug #10394)"
-        if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
-        run: composer remove --dev yoast/wp-test-utils --no-interaction
-
-      - name: "Install type 2: reinstall wp-test-utils with specific PHPUnit version (temporary - Composer bug #10394)"
-        if: ${{ steps.composer_toggle.outputs.TYPE == '2' }}
-        run: composer require --dev yoast/wp-test-utils:"^1.0.0" phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction
+        with:
+          # Force a `composer update` run.
+          dependency-versions: "highest"
+          # But make it selective.
+          composer-options: "yoast/wp-test-utils phpunit/phpunit --with-dependencies --ignore-platform-req=php"
 
       ### Install type 3.
       - name: "Install type 3: install Composer dependencies - WP < 5.9 with PHP < 8.0"


### PR DESCRIPTION
## Context

* Simplify CI

## Summary

This PR can be summarized in the following changelog entry:

* Simplify CI

## Relevant technical choices:

Follow up on #118

This reverts commit 126ecf730876b5e4cfbb7803a086fff682afd9b2.

Composer 2.2.3 has been released which contains a fix for the overly greedy optimization pass which was introduced in Composer 2.2.0.

With this fix in place, the previously introduced work-around for Composer 2.2 is no longer needed.

Refs:
* https://github.com/composer/composer/releases/tag/2.2.3
* https://github.com/composer/composer/issues/10394

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.