### PR TITLE
Composer: update PHPCS

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2160,16 +2160,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -2212,7 +2212,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2665,5 +2665,5 @@
     "platform-overrides": {
         "php": "5.6.40"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Context

* Update dev dependency

## Summary

This PR can be summarized in the following changelog entry:

* Update dev dependency

## Relevant technical choices:

PHPCS has had a few releases since the last update. These mostly add syntax support for PHP 8.1.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/releases


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.
