### PR TITLE
PHP 8.2: explicitly declare properties

### DIFF
--- a/tests/admin-test.php
+++ b/tests/admin-test.php
@@ -18,6 +18,13 @@ class Clicky_Admin_Test extends Clicky_UnitTestCase {
 	private static $class_instance;
 
 	/**
+	 * Temporary storage for admin options for a test.
+	 *
+	 * @var array
+	 */
+	private $options;
+
+	/**
 	 * Set up the class instance to be tested.
 	 */
 	public static function set_up_before_class() {


### PR DESCRIPTION
## Context

* Test maintenance

## Summary

This PR can be summarized in the following changelog entry:

* Test maintenance

## Relevant technical choices:

Explicitly declare properties as dynamic properties are bad practice anyway and will be deprecated in PHP 8.2.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.