### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -45,8 +45,9 @@ jobs:
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.
       # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
       - name: Check PHP code style
-        continue-on-error: true
+        id: phpcs
         run: composer check-cs -- --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,10 +1,10 @@
 name: CS
 
 on:
-  # Run on all pushes (except to master) and on all pull requests.
+  # Run on all pushes (except to main) and on all pull requests.
   push:
     branches-ignore:
-      - 'master'
+      - 'main'
   pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -40,6 +40,9 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       # Check the codestyle of the files.
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,9 +30,6 @@ jobs:
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 
-    # Allow builds to fail on as-of-yet unreleased PHP versions.
-    continue-on-error: ${{ matrix.php_version == '8.2' }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   # Run on pushes to select branches and on all pull requests.
   push:
     branches:
-      - master
+      - main
       - develop
       - 'release/[0-9]+.[0-9]+*'
       - 'hotfix/[0-9]+.[0-9]+*'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,6 +49,9 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   # Run on pushes to select branches and on all pull requests.
   push:
     branches:
-      - master
+      - main
       - develop
       - 'release/[0-9]+.[0-9]+*'
       - 'hotfix/[0-9]+.[0-9]+*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,14 @@ jobs:
             wp_version: 'latest'
             multisite: true
 
+          # WP 6.1 is the earliest version which supports PHP 8.2.
+          - php_version: '8.2'
+            wp_version: '6.1'
+            multisite: true
+
     name: "Integration Test: PHP ${{ matrix.php_version }} | WP ${{ matrix.wp_version }}${{ matrix.multisite == true && ' (+ ms)' || '' }}"
 
-    # Allow builds to fail on as-of-yet unreleased PHP versions.
+    # Allow builds to fail on as-of-yet unreleased WordPress versions.
     continue-on-error: ${{ matrix.wp_version == 'trunk' }}
 
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,8 @@ jobs:
           dependency-versions: "highest"
           # But make it selective.
           composer-options: "yoast/wp-test-utils --with-dependencies"
+          # Bust the cache at least once a month - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: Install WP
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ For localization, please refer to [translate.yoast.com](http://translate.yoast.c
   * Ensure you stick to the [WordPress Coding Standards](http://codex.wordpress.org/WordPress_Coding_Standards) and have properly documented any new functions.
   * Running `grunt check` to check for coding standards issues.
 * When committing, reference your issue (if present) and include a note about the fix.
-* Push the changes to your fork and submit a pull request to the 'master' branch of the Clicky for WordPress repository.
+* Push the changes to your fork and submit a pull request to the 'main' branch of the Clicky for WordPress repository.
 
 ## Code Documentation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here's a [guide on how to install Clicky in your WordPress site](https://yoast.c
 If you want to run the Git version though, you have two options:
 
 * You can clone the GitHub repository: https://github.com/Yoast/clicky.git
-* Download it directly as a ZIP file: https://github.com/Yoast/clicky/archive/master.zip
+* Download it directly as a ZIP file: https://github.com/Yoast/clicky/archive/main.zip
 
 This will download the latest release version of Clicky for WordPress by Yoast. While this version is usually stable,
 it is not recommended for use in a production environment.
@@ -41,7 +41,7 @@ This is a developer's portal for Clicky for WordPress by Yoast and should not be
 Contributions
 -------------
 Anyone is welcome to contribute to Clicky for WordPress. Please
-[read the guidelines](https://github.com/Yoast/clicky/blob/master/CONTRIBUTING.md) for contributing to this
+[read the guidelines](https://github.com/Yoast/clicky/blob/main/CONTRIBUTING.md) for contributing to this
 repository.
 
 There are various ways you can contribute:


### PR DESCRIPTION
## Context

* CI maintenance

## Summary

This PR can be summarized in the following changelog entry:

* CI maintenance

## Relevant technical choices:

### GH Actions: harden the workflow against PHPCS ruleset errors

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.

### GH Actions: clean up after branch rename

Make sure branch names in the branch selection are correct to ensure builds will still run when appropriate.

### GH Actions: bust the cache semi-regularly

Caches used in GH Actions do not get updated, they can only be replaced by a different cache with a different cache key.

Now the predefined Composer install action this repo is using already creates a pretty comprehensive cache key:

> `ramsey/composer-install` will auto-generate a cache key which is composed of
the following elements:
> * The OS image name, like `ubuntu-latest`.
> * The exact PHP version, like `8.1.11`.
> * The options passed via `composer-options`.
> * The dependency version setting as per `dependency-versions`.
> * The working directory as per `working-directory`.
> * A hash of the `composer.json` and/or `composer.lock` files.

This means that aside from other factors, the cache will always be busted when changes are made to the (committed) `composer.json` or the `composer.lock` file (if the latter exists in the repo).

For packages running on recent versions of PHP, it also means that the cache will automatically be busted once a month when a new PHP version comes out.

#### The problem

For runs on older PHP versions which don't receive updates anymore, the cache will not be busted via new PHP version releases, so effectively, the cache will only be busted when a change is made to the `composer.json`/`composer.lock` file - which may not happen that frequently on low-traffic repos.

But... packages _in use_ on those older PHP versions - especially dependencies of declared dependencies - may still release new versions and those new versions will not exist in the cache and will need to be downloaded each time the action is run and over time the cache gets less and less relevant as more and more packages will need to be downloaded for each run.

#### The solution

To combat this issue, a new `custom-cache-suffix` option has been added to the Composer install action in version 2.2.0.
This new option allows for providing some extra information to add to the cache key, which allows for busting the cache based on your own additional criteria.

This commit implements the use of this `custom-cache-suffix` option for all relevant workflows in this repo.

Refs:
* https://github.com/ramsey/composer-install/#custom-cache-suffix
* https://github.com/ramsey/composer-install/releases/tag/2.2.0

### GH Actions: don't allow linting issues on PHP 8.2

### GH Actions: run the tests against PHP 8.2

... and as the tests currently pass without issue, don't allow the build to fail.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_